### PR TITLE
fix global knitr options

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -39,10 +39,11 @@ execute:
   freeze: auto
   cache: true
   code-line-numbers: true
-  knitr:
-    opts_knit:
-      echo: true
-      fig.width: 15
+
+knitr:
+  opts_chunk:
+    echo: true
+    fig.width: 15
 
 editor: visual
 highlight-style: github


### PR DESCRIPTION
a good test would be to put `eval: false` - it was not working previously

hopefully that would fix screenshooting issue