### PR TITLE
add session info + lock file to every TLGs

### DIFF
--- a/appendix/session.qmd
+++ b/appendix/session.qmd
@@ -15,8 +15,9 @@ sessionInfo()
 
 ## `renv.lock` file
 
-```{r snapshot, echo=FALSE, message=FALSE}
+```{r snapshot}
 #| code-fold: show
+#| renv.ignore: TRUE
 
 renv::snapshot("..", lockfile = "../assets/www/renv.lock", prompt = FALSE, force = TRUE)
 ```

--- a/graphs/other/brg01.qmd
+++ b/graphs/other/brg01.qmd
@@ -290,4 +290,7 @@ ggplot(anl, aes(x = .data[["ACTARM"]], fill = .data[["AETOXGRC"]])) +
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/bwg01.qmd
+++ b/graphs/other/bwg01.qmd
@@ -418,4 +418,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/cig01.qmd
+++ b/graphs/other/cig01.qmd
@@ -230,4 +230,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/fstg01.qmd
+++ b/graphs/other/fstg01.qmd
@@ -247,4 +247,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/fstg02.qmd
+++ b/graphs/other/fstg02.qmd
@@ -264,4 +264,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/ippg01.qmd
+++ b/graphs/other/ippg01.qmd
@@ -160,4 +160,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/kmg01.qmd
+++ b/graphs/other/kmg01.qmd
@@ -160,4 +160,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/ltg01.qmd
+++ b/graphs/other/ltg01.qmd
@@ -214,4 +214,7 @@ g53
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/mmrmg01.qmd
+++ b/graphs/other/mmrmg01.qmd
@@ -169,4 +169,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/mmrmg02.qmd
+++ b/graphs/other/mmrmg02.qmd
@@ -125,4 +125,7 @@ g_forest(
   vline = 0
 )
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/other/mng01.qmd
+++ b/graphs/other/mng01.qmd
@@ -174,4 +174,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkcg01.qmd
+++ b/graphs/pharmacokinetic/pkcg01.qmd
@@ -90,4 +90,7 @@ result[[1]] + ggplot2::scale_y_log10(breaks = c(0.001, 0.01, 0.1, 1, 10), label 
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkcg02.qmd
+++ b/graphs/pharmacokinetic/pkcg02.qmd
@@ -92,4 +92,7 @@ result + ggplot2::scale_y_log10(breaks = c(0.001, 0.01, 0.1, 1, 10), label = c(0
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkcg03.qmd
+++ b/graphs/pharmacokinetic/pkcg03.qmd
@@ -101,4 +101,7 @@ result + theme(plot.caption = element_text(hjust = 0)) +
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkpg01.qmd
+++ b/graphs/pharmacokinetic/pkpg01.qmd
@@ -137,4 +137,7 @@ result + theme(plot.caption = element_text(hjust = 0)) +
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkpg02.qmd
+++ b/graphs/pharmacokinetic/pkpg02.qmd
@@ -145,4 +145,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkpg03.qmd
+++ b/graphs/pharmacokinetic/pkpg03.qmd
@@ -51,4 +51,7 @@ p <- ggplot(adpp, aes(x = AVISIT, y = AVAL, fill = ACTARM, label = SUBJID)) +
 
 p
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkpg04.qmd
+++ b/graphs/pharmacokinetic/pkpg04.qmd
@@ -52,4 +52,7 @@ p <- ggplot(adpp, aes(x = AVISIT, y = AVAL, fill = ACTARM, label = SUBJID)) +
 
 p + geom_point(aes(fill = ACTARM), size = 2, shape = 21, position = position_dodge(0.75))
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/graphs/pharmacokinetic/pkpg06.qmd
+++ b/graphs/pharmacokinetic/pkpg06.qmd
@@ -180,4 +180,7 @@ p
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/si.qmd
+++ b/si.qmd
@@ -1,0 +1,23 @@
+## Session Info
+
+### Session Info
+
+```{r sessioninfo, message=FALSE}
+#| code-fold: show
+
+sessionInfo()
+```
+
+### `renv.lock` file
+
+```{r snapshot}
+#| code-fold: show
+#| renv.ignore: TRUE
+
+parent_file_path <- knitr::current_input(dir = TRUE)
+lock_path <- file.path("../../assets/www/lock", paste0(gsub(file.path(Sys.getenv("QUARTO_PROJECT_DIR"), ""), "", knitr::current_input(dir = TRUE)), ".lock"))
+
+renv::snapshot(parent_file_path, lockfile = lock_path, prompt = FALSE, force = TRUE)
+```
+
+[Download](`r lock_path`)

--- a/tables/adverse-events/aet01.qmd
+++ b/tables/adverse-events/aet01.qmd
@@ -447,4 +447,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet01_aesi.qmd
+++ b/tables/adverse-events/aet01_aesi.qmd
@@ -648,4 +648,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet02.qmd
+++ b/tables/adverse-events/aet02.qmd
@@ -709,4 +709,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet02_smq.qmd
+++ b/tables/adverse-events/aet02_smq.qmd
@@ -216,4 +216,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet03.qmd
+++ b/tables/adverse-events/aet03.qmd
@@ -152,4 +152,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet04.qmd
+++ b/tables/adverse-events/aet04.qmd
@@ -535,4 +535,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet04_pi.qmd
+++ b/tables/adverse-events/aet04_pi.qmd
@@ -417,4 +417,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet05.qmd
+++ b/tables/adverse-events/aet05.qmd
@@ -130,4 +130,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet05_all.qmd
+++ b/tables/adverse-events/aet05_all.qmd
@@ -137,4 +137,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet06.qmd
+++ b/tables/adverse-events/aet06.qmd
@@ -402,4 +402,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet06_smq.qmd
+++ b/tables/adverse-events/aet06_smq.qmd
@@ -321,4 +321,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet07.qmd
+++ b/tables/adverse-events/aet07.qmd
@@ -200,4 +200,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet09.qmd
+++ b/tables/adverse-events/aet09.qmd
@@ -220,4 +220,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet09_smq.qmd
+++ b/tables/adverse-events/aet09_smq.qmd
@@ -225,4 +225,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/adverse-events/aet10.qmd
+++ b/tables/adverse-events/aet10.qmd
@@ -142,4 +142,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/aovt01.qmd
+++ b/tables/efficacy/aovt01.qmd
@@ -123,4 +123,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/coxt01.qmd
+++ b/tables/efficacy/coxt01.qmd
@@ -233,4 +233,7 @@ app <- init(
 )
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/coxt02.qmd
+++ b/tables/efficacy/coxt02.qmd
@@ -188,4 +188,7 @@ app <- init(
 )
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/dort01.qmd
+++ b/tables/efficacy/dort01.qmd
@@ -317,4 +317,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/lgrt02.qmd
+++ b/tables/efficacy/lgrt02.qmd
@@ -204,4 +204,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/mmrmt01.qmd
+++ b/tables/efficacy/mmrmt01.qmd
@@ -269,4 +269,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/onct05.qmd
+++ b/tables/efficacy/onct05.qmd
@@ -192,4 +192,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/rspt01.qmd
+++ b/tables/efficacy/rspt01.qmd
@@ -314,4 +314,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/efficacy/ttet01.qmd
+++ b/tables/efficacy/ttet01.qmd
@@ -444,4 +444,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt01.qmd
+++ b/tables/lab-results/lbt01.qmd
@@ -111,4 +111,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt02.qmd
+++ b/tables/lab-results/lbt02.qmd
@@ -107,4 +107,7 @@ app <- init(
 )
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt03.qmd
+++ b/tables/lab-results/lbt03.qmd
@@ -205,4 +205,7 @@ app <- init(
 )
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt04.qmd
+++ b/tables/lab-results/lbt04.qmd
@@ -115,4 +115,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt05.qmd
+++ b/tables/lab-results/lbt05.qmd
@@ -186,4 +186,7 @@ result
 # and use it in `trim_levels_to_map`.
 # this is an a posteriori approach, though.
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt06.qmd
+++ b/tables/lab-results/lbt06.qmd
@@ -95,4 +95,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt07.qmd
+++ b/tables/lab-results/lbt07.qmd
@@ -149,4 +149,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt08.qmd
+++ b/tables/lab-results/lbt08.qmd
@@ -74,4 +74,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt09.qmd
+++ b/tables/lab-results/lbt09.qmd
@@ -158,4 +158,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt10.qmd
+++ b/tables/lab-results/lbt10.qmd
@@ -94,4 +94,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt10_bl.qmd
+++ b/tables/lab-results/lbt10_bl.qmd
@@ -94,4 +94,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt11.qmd
+++ b/tables/lab-results/lbt11.qmd
@@ -197,4 +197,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt11_bl.qmd
+++ b/tables/lab-results/lbt11_bl.qmd
@@ -197,4 +197,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt12.qmd
+++ b/tables/lab-results/lbt12.qmd
@@ -75,4 +75,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt12_bl.qmd
+++ b/tables/lab-results/lbt12_bl.qmd
@@ -75,4 +75,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt13.qmd
+++ b/tables/lab-results/lbt13.qmd
@@ -470,4 +470,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt14.qmd
+++ b/tables/lab-results/lbt14.qmd
@@ -410,4 +410,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/lab-results/lbt15.qmd
+++ b/tables/lab-results/lbt15.qmd
@@ -207,4 +207,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/aovt02.qmd
+++ b/tables/other/aovt02.qmd
@@ -132,4 +132,7 @@ app <- init(
 )
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/aovt03.qmd
+++ b/tables/other/aovt03.qmd
@@ -72,4 +72,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/cmht01.qmd
+++ b/tables/other/cmht01.qmd
@@ -179,4 +179,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/disclosurest01.qmd
+++ b/tables/other/disclosurest01.qmd
@@ -377,4 +377,7 @@ lyt <- basic_table(show_colcounts = TRUE) %>%
 result <- build_table(lyt, adae, alt_counts_df = adsl)
 result
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/ratet01.qmd
+++ b/tables/other/ratet01.qmd
@@ -79,4 +79,7 @@ result
 
 # In Progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/rbmit01.qmd
+++ b/tables/other/rbmit01.qmd
@@ -203,4 +203,7 @@ basic_table() %>%
   summarize_rbmi() %>%
   build_table(df)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/rmpt01.qmd
+++ b/tables/other/rmpt01.qmd
@@ -174,4 +174,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/rmpt03.qmd
+++ b/tables/other/rmpt03.qmd
@@ -223,4 +223,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/rmpt04.qmd
+++ b/tables/other/rmpt04.qmd
@@ -135,4 +135,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/rmpt05.qmd
+++ b/tables/other/rmpt05.qmd
@@ -141,4 +141,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/other/rmpt06.qmd
+++ b/tables/other/rmpt06.qmd
@@ -330,4 +330,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/adat01.qmd
+++ b/tables/pharmacokinetic/adat01.qmd
@@ -219,4 +219,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/adat02.qmd
+++ b/tables/pharmacokinetic/adat02.qmd
@@ -135,4 +135,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/adat03.qmd
+++ b/tables/pharmacokinetic/adat03.qmd
@@ -120,4 +120,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/adat04a.qmd
+++ b/tables/pharmacokinetic/adat04a.qmd
@@ -224,4 +224,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/adat04b.qmd
+++ b/tables/pharmacokinetic/adat04b.qmd
@@ -209,4 +209,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkct01.qmd
+++ b/tables/pharmacokinetic/pkct01.qmd
@@ -105,4 +105,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt02.qmd
+++ b/tables/pharmacokinetic/pkpt02.qmd
@@ -87,4 +87,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt03.qmd
+++ b/tables/pharmacokinetic/pkpt03.qmd
@@ -104,4 +104,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt04.qmd
+++ b/tables/pharmacokinetic/pkpt04.qmd
@@ -87,4 +87,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt05.qmd
+++ b/tables/pharmacokinetic/pkpt05.qmd
@@ -104,4 +104,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt06.qmd
+++ b/tables/pharmacokinetic/pkpt06.qmd
@@ -88,4 +88,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt07.qmd
+++ b/tables/pharmacokinetic/pkpt07.qmd
@@ -105,4 +105,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt08.qmd
+++ b/tables/pharmacokinetic/pkpt08.qmd
@@ -90,4 +90,7 @@ cat(rtables::toString(result, indent_size = 10))
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/pharmacokinetic/pkpt11.qmd
+++ b/tables/pharmacokinetic/pkpt11.qmd
@@ -153,4 +153,7 @@ cat(rtables::toString(result, indent_size = 24))
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/cmt01.qmd
+++ b/tables/safety/cmt01.qmd
@@ -286,4 +286,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/cmt01a.qmd
+++ b/tables/safety/cmt01a.qmd
@@ -299,4 +299,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/cmt01b.qmd
+++ b/tables/safety/cmt01b.qmd
@@ -315,4 +315,7 @@ app <- teal::init(
 )
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/cmt02_pt.qmd
+++ b/tables/safety/cmt02_pt.qmd
@@ -135,4 +135,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/dmt01.qmd
+++ b/tables/safety/dmt01.qmd
@@ -220,4 +220,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/dst01.qmd
+++ b/tables/safety/dst01.qmd
@@ -208,4 +208,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/dtht01.qmd
+++ b/tables/safety/dtht01.qmd
@@ -239,4 +239,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/egt01.qmd
+++ b/tables/safety/egt01.qmd
@@ -108,4 +108,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/egt02.qmd
+++ b/tables/safety/egt02.qmd
@@ -143,4 +143,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/egt03.qmd
+++ b/tables/safety/egt03.qmd
@@ -194,4 +194,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/egt04.qmd
+++ b/tables/safety/egt04.qmd
@@ -89,4 +89,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/egt05_qtcat.qmd
+++ b/tables/safety/egt05_qtcat.qmd
@@ -241,4 +241,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/enrollment01.qmd
+++ b/tables/safety/enrollment01.qmd
@@ -204,4 +204,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/eudrat01.qmd
+++ b/tables/safety/eudrat01.qmd
@@ -95,4 +95,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/eudrat02.qmd
+++ b/tables/safety/eudrat02.qmd
@@ -72,4 +72,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/ext01.qmd
+++ b/tables/safety/ext01.qmd
@@ -276,4 +276,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/mht01.qmd
+++ b/tables/safety/mht01.qmd
@@ -202,4 +202,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/pdt01.qmd
+++ b/tables/safety/pdt01.qmd
@@ -104,4 +104,7 @@ app <- teal::init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/pdt02.qmd
+++ b/tables/safety/pdt02.qmd
@@ -60,4 +60,7 @@ result
 
 # In progress
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/vst01.qmd
+++ b/tables/safety/vst01.qmd
@@ -231,4 +231,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::

--- a/tables/safety/vst02.qmd
+++ b/tables/safety/vst02.qmd
@@ -129,4 +129,7 @@ app <- init(
 
 shinyApp(app$ui, app$server)
 ```
+
+{{< include ../../si.qmd >}}
+
 :::


### PR DESCRIPTION
Currently there is only one big lock file that covers _all_ TLGs. I believe that in most of the cases that's too much and would include many not-required packages such as `mmrm` or `rbmi`. We need some minimal sessioninfo + lock file on individual TLG level. This is the most minimalistic approach that I could came up with.