### PR TITLE
Merger draft to discuss

### DIFF
--- a/tables/adverse-events/aet01.qmd
+++ b/tables/adverse-events/aet01.qmd
@@ -6,12 +6,8 @@ subtitle: Safety Summary
 ------------------------------------------------------------------------
 
 ::: panel-tabset
-## Data Setup
-
-To illustrate, additional variables such as flags (TRUE/FALSE) for select AEs of interest and select AE baskets are added to the `adae` dataset.
-
-```{r setup, message=FALSE}
-#| code-fold: show
+```{r setup, message=FALSE, echo=FALSE}
+setup_aet01 <- '#| code-fold: show
 
 library(tern)
 library(dplyr)
@@ -75,6 +71,16 @@ adae <- adae %>%
     SMQ02 = aesi_label(adae$SMQ02NAM, adae$SMQ02SC),
     CQ01 = aesi_label(adae$CQ01NAM)
   )
+'
+eval(parse(text = setup_aet01))
+```
+
+```{r results='asis', echo=FALSE}
+cat("## Data Setup\n")
+cat("To illustrate, additional variables such as flags (TRUE/FALSE) for select AEs of interest and select AE baskets are added to the `adae` dataset.\n")
+cat("```r")
+cat(setup_aet01)
+cat("```\n\n")
 ```
 
 ## Standard Table
@@ -449,5 +455,4 @@ shinyApp(app$ui, app$server)
 ```
 
 {{< include ../../si.qmd >}}
-
 :::


### PR DESCRIPTION
The problem is code duplication. Viable solutions:

1. Keep "Book" package and "Test" package separated but have the code in the form of text (and tested/executed with `eval(parse(text=<>))`. Then in Quarto here it is just printed out as it is done in `teal.gallery` (https://insightsengineering.github.io/teal.gallery/main/articles/sources.html and https://github.com/insightsengineering/teal.gallery/blob/main/vignettes/sources.Rmd#L33).
2. Have only one package with the same `scda.test` structure but with "Book" generating features.

Note: `teal.gallery` gets the source code from the source files with https://github.com/insightsengineering/teal.gallery/blob/00547871a0a0131857dc6938ea153edad3df2c5c/R/utils.R#L27

This Draft PR just shows the wiz of it. The print is identical but the show-code which can be probably fixed