### PR TITLE
Update LB table templates with modifications from chevron

### DIFF
--- a/tables/efficacy/cfbt01.qmd
+++ b/tables/efficacy/cfbt01.qmd
@@ -64,9 +64,9 @@ afun <- function(x, .var, .spl_context, ...) {
 lyt <- basic_table() %>%
   split_cols_by("ARM") %>%
   split_rows_by(
-    "PARAM", 
-    split_fun = split_fun, 
-    label_pos = "topleft", 
+    "PARAM",
+    split_fun = split_fun,
+    label_pos = "topleft",
     split_label = obj_label(adqs$PARAM)
   ) %>%
   split_rows_by(

--- a/tables/efficacy/cfbt01.qmd
+++ b/tables/efficacy/cfbt01.qmd
@@ -27,9 +27,6 @@ adqs <- adqs %>%
   dplyr::filter(
     PARAM == "BFI All Questions",
     AVISIT != "SCREENING"
-  ) %>%
-  var_relabel(
-    AVISIT = "Visit"
   )
 
 # Define the split function for AVISIT
@@ -39,8 +36,39 @@ split_fun <- drop_split_levels
 ## Standard Table
 
 ```{r}
+afun <- function(x, .var, .spl_context, ...) {
+  n_fun <- sum(!is.na(x), na.rm = TRUE)
+  if (n_fun == 0) {
+    mean_sd_fun <- c(NA, NA)
+    median_fun <- NA
+    min_max_fun <- c(NA, NA)
+  } else {
+    mean_sd_fun <- c(mean(x, na.rm = TRUE), sd(x, na.rm = TRUE))
+    median_fun <- median(x, na.rm = TRUE)
+    min_max_fun <- c(min(x), max(x))
+  }
+  is_chg <- .var == "CHG"
+  is_baseline <- .spl_context$value[which(.spl_context$split == "AVISIT")] == "BASELINE"
+  if (is_baseline && is_chg) n_fun <- mean_sd_fun <- median_fun <- min_max_fun <- NULL
+
+  in_rows(
+    "n" = n_fun,
+    "Mean (SD)" = mean_sd_fun,
+    "Median" = median_fun,
+    "Min - Max" = min_max_fun,
+    .formats = list("n" = "xx", "Mean (SD)" = "xx.xx (xx.xx)", "Median" = "xx.xx", "Min - Max" = "xx.xx - xx.xx"),
+    .format_na_strs = list("n" = "NE", "Mean (SD)" = "NE (NE)", "Median" = "NE", "Min - Max" = "NE - NE")
+  )
+}
+
 lyt <- basic_table() %>%
   split_cols_by("ARM") %>%
+  split_rows_by(
+    "PARAM", 
+    split_fun = split_fun, 
+    label_pos = "topleft", 
+    split_label = obj_label(adqs$PARAM)
+  ) %>%
   split_rows_by(
     "AVISIT",
     split_fun = split_fun,
@@ -51,7 +79,7 @@ lyt <- basic_table() %>%
     vars = c("AVAL", "CHG"),
     varlabels = c("Value at Visit", "Change from\nBaseline")
   ) %>%
-  summarize_colvars()
+  analyze_colvars(afun = afun)
 
 result <- build_table(lyt, adqs)
 result

--- a/tables/lab-results/lbt01.qmd
+++ b/tables/lab-results/lbt01.qmd
@@ -22,7 +22,8 @@ adlb <- synthetic_cdisc_dataset("latest", "adlb")
 
 # Ensure character variables are converted to factors and empty strings and NAs are explicit missing levels.
 adsl <- df_explicit_na(adsl)
-adlb <- df_explicit_na(adlb)
+adlb <- df_explicit_na(adlb) %>%
+  filter(ANL01FL == "Y")
 
 # For illustration purpose, the example focuses on "Alanine Aminotransferase
 # Measurement" starting from baseline, while excluding visit at week 1 for
@@ -30,7 +31,7 @@ adlb <- df_explicit_na(adlb)
 adlb_f <- adlb %>%
   dplyr::filter(
     PARAM == "Alanine Aminotransferase Measurement" &
-      !(ARM == "B: Placebo" & AVISIT == "WEEK 1 DAY 8") &
+      !(ACTARM == "B: Placebo" & AVISIT == "WEEK 1 DAY 8") &
       AVISIT != "SCREENING"
   )
 ```
@@ -41,14 +42,40 @@ adlb_f <- adlb %>%
 # Define the split function
 split_fun <- drop_split_levels
 
-lyt <- basic_table() %>%
-  split_cols_by("ARM") %>%
+afun <- function(x, .var, .spl_context, ...) {
+  n_fun <- sum(!is.na(x), na.rm = TRUE)
+  if (n_fun == 0) {
+    mean_sd_fun <- c(NA, NA)
+    median_fun <- NA
+    min_max_fun <- c(NA, NA)
+  } else {
+    mean_sd_fun <- c(mean(x, na.rm = TRUE), sd(x, na.rm = TRUE))
+    median_fun <- median(x, na.rm = TRUE)
+    min_max_fun <- c(min(x), max(x))
+  }
+  is_chg <- .var == "CHG"
+  is_baseline <- .spl_context$value[which(.spl_context$split == "AVISIT")] == "BASELINE"
+  if (is_baseline && is_chg) n_fun <- mean_sd_fun <- median_fun <- min_max_fun <- NULL
+
+  in_rows(
+    "n" = n_fun,
+    "Mean (SD)" = mean_sd_fun,
+    "Median" = median_fun,
+    "Min - Max" = min_max_fun,
+    .formats = list("n" = "xx", "Mean (SD)" = "xx.xx (xx.xx)", "Median" = "xx.xx", "Min - Max" = "xx.xx - xx.xx"),
+    .format_na_strs = list("n" = "NE", "Mean (SD)" = "NE (NE)", "Median" = "NE", "Min - Max" = "NE - NE")
+  )
+}
+
+lyt <- basic_table(show_colcounts = TRUE) %>%
+  split_cols_by("ACTARM") %>%
+  split_rows_by("PARAM", split_fun = split_fun, label_pos = "topleft", split_label = obj_label(adlb_f$PARAM)) %>%
   split_rows_by("AVISIT", split_fun = split_fun, label_pos = "topleft", split_label = obj_label(adlb_f$AVISIT)) %>%
   split_cols_by_multivar(
     vars = c("AVAL", "CHG"),
-    varlabels = c("Analysis Value", "Absolute Change from Baseline")
+    varlabels = c("Value at Visit", "Change from\nBaseline")
   ) %>%
-  summarize_colvars()
+  analyze_colvars(afun = afun)
 
 result <- build_table(lyt, adlb_f)
 result
@@ -113,5 +140,4 @@ shinyApp(app$ui, app$server)
 ```
 
 {{< include ../../si.qmd >}}
-
 :::

--- a/tables/lab-results/lbt04.qmd
+++ b/tables/lab-results/lbt04.qmd
@@ -22,44 +22,30 @@ adlb <- synthetic_cdisc_dataset("latest", "adlb")
 adsl <- df_explicit_na(adsl)
 adlb <- df_explicit_na(adlb)
 
-adlb <- adlb %>%
-  mutate(ONTRTFL = ifelse(AVISIT %in% c("SCREENING", "BASELINE"), "", "Y")) %>%
-  var_relabel(PARAM = "Laboratory Test")
-
 adlb_f <- adlb %>%
-  dplyr::filter(ONTRTFL == "Y")
-
-# We derive the PARCAT1 variable from LBCAT as an example of how to work with real data.
-adlb_f$PARCAT1 <- adlb_f$LBCAT
-
-# Create a map based on the rule that at least one record with ANRLO > 0 as low, at least one ANRHI is not missing as
-# high using the h_map_for_count_abnormal with method as "range".
-map <- h_map_for_count_abnormal(
-  df = adlb_f,
-  variables = list(anl = "ANRIND", split_rows = c("PARCAT1", "PARAM"), range_low = "ANRLO", range_high = "ANRHI"),
-  abnormal = list(low = "LOW", high = "HIGH"),
-  method = "range",
-  na_level = "<Missing>"
-)
+  filter(ONTRTFL == "Y", ANRIND != "<Missing>") %>%
+  var_relabel(
+    PARAM = "Laboratory Test",
+    ANRIND = "Direction of Abnormality"
+  )
 ```
 
 ## Standard Table
 
 ```{r variant 1}
 lyt <- basic_table(show_colcounts = TRUE) %>%
-  split_cols_by("ARM") %>%
-  split_rows_by("PARCAT1", split_fun = trim_levels_to_map(map = map)) %>%
+  split_cols_by("ACTARM") %>%
   split_rows_by("PARAM",
-    split_fun = trim_levels_to_map(map = map),
+    split_fun = drop_split_levels,
     label_pos = "topleft",
     split_label = obj_label(adlb_f$PARAM)
   ) %>%
   count_abnormal(
     var = "ANRIND",
-    abnormal = list(Low = "LOW", High = "HIGH"),
+    abnormal = list(Low = c("LOW", "LOW LOW"), High = c("HIGH", "HIGH HIGH")),
     exclude_base_abn = TRUE
   ) %>%
-  append_varlabels(adlb_f, "ANRIND", indent = 2L)
+  append_varlabels(adlb_f, "ANRIND", indent = 1L)
 
 result <- build_table(lyt = lyt, df = adlb_f, alt_counts_df = adsl)
 
@@ -77,16 +63,14 @@ library(dplyr)
 
 adsl <- synthetic_cdisc_dataset("latest", "adsl")
 adlb <- synthetic_cdisc_dataset("latest", "adlb") %>%
-  mutate(ONTRTFL = ifelse(AVISIT %in% c("SCREENING", "BASELINE"), "", "Y")) %>%
-  var_relabel(PARAM = "Laboratory Test")
+  var_relabel(PARAM = "Laboratory Test", ANRIND = "Direction of Abnormality")
 
 app <- init(
   data = cdisc_data(
     cdisc_dataset("ADSL", adsl, code = 'ADSL <- synthetic_cdisc_dataset("latest", "adsl")'),
     cdisc_dataset("ADLB", adlb, code = '
                   ADLB <- synthetic_cdisc_dataset("latest", "adlb") %>%
-                mutate(ONTRTFL = ifelse(AVISIT %in% c("SCREENING", "BASELINE"), "", "Y")) %>%
-                var_relabel(PARAM = "Laboratory Test")'),
+                var_relabel(PARAM = "Laboratory Test", ANRIND = "Direction of Abnormality")'),
     check = TRUE
   ),
   modules = modules(
@@ -117,5 +101,4 @@ shinyApp(app$ui, app$server)
 ```
 
 {{< include ../../si.qmd >}}
-
 :::

--- a/tables/lab-results/lbt05.qmd
+++ b/tables/lab-results/lbt05.qmd
@@ -22,9 +22,6 @@ adlb <- synthetic_cdisc_dataset("latest", "adlb")
 adsl <- df_explicit_na(adsl)
 adlb <- df_explicit_na(adlb)
 
-# Modify ANRIND and create AVALCAT1/PARCAT2
-# PARCAT2 is just used for filtering, but in order to be the
-# filtering as realistic as possible, will create the variable.
 qntls <- adlb %>%
   group_by(PARAMCD) %>%
   summarise(as_tibble(t(quantile(AVAL, probs = c(0.1, 0.9)))), .groups = "drop_last") %>%
@@ -33,9 +30,11 @@ qntls <- adlb %>%
 adlb <- adlb %>%
   left_join(qntls, by = "PARAMCD")
 
-avalcat1 <- c("LAST", "REPLICATED", "SINGLE")
-
 set.seed(1)
+
+# Modify ANRIND and create AVALCAT1/PARCAT2
+# PARCAT2 is just used for filtering, but in order to be the
+# filtering as realistic as possible, will create the variable.
 adlb <- adlb %>%
   mutate(
     ANRIND = factor(
@@ -49,10 +48,10 @@ adlb <- adlb %>%
     AVALCAT1 = factor(
       case_when(
         ANRIND %in% c("HIGH HIGH", "LOW LOW") ~
-          sample(x = avalcat1, size = n(), replace = TRUE, prob = c(0.3, 0.6, 0.1)),
+          sample(x = c("LAST", "REPLICATED", "SINGLE"), size = n(), replace = TRUE, prob = c(0.3, 0.6, 0.1)),
         TRUE ~ ""
       ),
-      levels = c("", avalcat1)
+      levels = c("", c("LAST", "REPLICATED", "SINGLE"))
     ),
     PARCAT2 = factor(ifelse(ANRIND %in% c("HIGH HIGH", "LOW LOW"), "LS",
       sample(c("SI", "CV", "LS"), size = n(), replace = TRUE)
@@ -67,7 +66,8 @@ adlb_f <- adlb %>%
     ANRIND == "LOW LOW" ~ "Low",
     ANRIND == "HIGH HIGH" ~ "High",
     TRUE ~ ""
-  )))
+  ), levels = c("Low", "High", ""))) %>%
+  df_explicit_na()
 
 # Construct analysis map
 map <- expand.grid(
@@ -76,39 +76,31 @@ map <- expand.grid(
   stringsAsFactors = FALSE
 ) %>%
   arrange(PARAM, desc(abn_dir))
-
-adlb_f <- df_explicit_na(adlb_f, na_level = "<Missing>")
 ```
 
 ## Standard Table
 
 ```{r variant 1}
 lyt <- basic_table(show_colcounts = TRUE) %>%
-  split_cols_by("ACTARMCD") %>%
+  split_cols_by("ACTARM") %>%
   split_rows_by(
     "PARAM",
     label_pos = "topleft",
     split_label = "Laboratory Test"
   ) %>%
   summarize_num_patients(var = "USUBJID", .stats = "unique_count") %>%
-  append_topleft("  Direction of Abnormality") %>%
   split_rows_by("abn_dir", split_fun = trim_levels_to_map(map)) %>%
   count_abnormal_by_marked(
     var = "AVALCAT1",
     variables = list(id = "USUBJID", param = "PARAM", direction = "abn_dir")
-  )
+  ) %>%
+  append_topleft("  Direction of Abnormality")
 
 result <- build_table(lyt, df = adlb_f, alt_counts_df = adsl)
 
-all_zero_or_na_not_any <- function(tr) {
-  if (!is(tr, "TableRow") || is(tr, "LabelRow") || obj_label(tr) == "Any Abnormality") {
-    return(FALSE)
-  }
-  rvs <- unlist(unname(row_values(tr)))
-  all(is.na(rvs) | rvs == 0 | !is.finite(rvs))
-}
+has_lbl <- function(lbl) CombinationFunction(function(tr) obj_label(tr) == lbl || sum(unlist(row_values(tr))) != 0)
+result <- prune_table(result, keep_rows(has_lbl("Any Abnormality")))
 
-result <- trim_rows(result, criteria = all_zero_or_na_not_any)
 result
 ```
 
@@ -116,19 +108,19 @@ result
 
 ```{r variant 2}
 lyt <- basic_table(show_colcounts = TRUE) %>%
-  split_cols_by("ACTARMCD") %>%
+  split_cols_by("ACTARM") %>%
   split_rows_by(
     "PARAM",
     label_pos = "topleft",
     split_label = "Laboratory Test"
   ) %>%
   summarize_num_patients(var = "USUBJID", .stats = "unique_count") %>%
-  append_topleft("  Direction of Abnormality") %>%
   split_rows_by("abn_dir", split_fun = trim_levels_to_map(map)) %>%
   count_abnormal_by_marked(
     var = "AVALCAT1",
     variables = list(id = "USUBJID", param = "PARAM", direction = "abn_dir")
-  )
+  ) %>%
+  append_topleft("  Direction of Abnormality")
 
 result <- build_table(lyt, df = adlb_f, alt_counts_df = adsl)
 
@@ -148,7 +140,7 @@ result
 
 ```{r variant 4}
 lyt <- basic_table(show_colcounts = TRUE) %>%
-  split_cols_by("ACTARMCD") %>%
+  split_cols_by("ACTARM") %>%
   split_rows_by(
     "PARAM",
     label_pos = "topleft",
@@ -156,16 +148,16 @@ lyt <- basic_table(show_colcounts = TRUE) %>%
     split_fun = trim_levels_in_group("abn_dir", drop_outlevs = TRUE)
   ) %>%
   summarize_num_patients(var = "USUBJID", .stats = "unique_count") %>%
-  append_topleft("  Direction of Abnormality") %>%
   split_rows_by("abn_dir") %>%
   count_abnormal_by_marked(
     var = "AVALCAT1",
     variables = list(id = "USUBJID", param = "PARAM", direction = "abn_dir")
-  )
+  ) %>%
+  append_topleft("  Direction of Abnormality")
 
-# we should still use the prune_table() function to obtain the desired output.
-result <- build_table(lyt, df = adlb_f, alt_counts_df = adsl) %>%
-  prune_table()
+result <- build_table(lyt, df = adlb_f, alt_counts_df = adsl)
+
+result <- result %>% prune_table()
 result
 
 # Another approach would be to create an empirical map by removing the ALT records

--- a/tables/lab-results/lbt07.qmd
+++ b/tables/lab-results/lbt07.qmd
@@ -59,12 +59,12 @@ adlb_f <- adlb_f %>%
 
 # Construct analysis map
 map <- expand.grid(
-    PARAM = levels(adlb$PARAM),
-    GRADE_DIR = c("LOW", "HIGH"),
-    GRADE_ANL = as.character(1:4),
-    stringsAsFactors = FALSE
-  ) %>%
-    arrange(PARAM, desc(GRADE_DIR), GRADE_ANL)
+  PARAM = levels(adlb$PARAM),
+  GRADE_DIR = c("LOW", "HIGH"),
+  GRADE_ANL = as.character(1:4),
+  stringsAsFactors = FALSE
+) %>%
+  arrange(PARAM, desc(GRADE_DIR), GRADE_ANL)
 ```
 
 ## Standard Table

--- a/tables/lab-results/lbt07.qmd
+++ b/tables/lab-results/lbt07.qmd
@@ -27,11 +27,9 @@ adlb <- df_explicit_na(adlb)
 
 # Select worst post-baseline records.
 adlb_f <- adlb %>%
-  filter(!AVISIT %in% c("SCREENING", "BASELINE")) %>%
   filter(ATOXGR != "<Missing>") %>%
   filter(ONTRTFL == "Y") %>%
-  filter(WGRLOFL == "Y" | WGRHIFL == "Y") %>%
-  droplevels()
+  filter(WGRLOFL == "Y" | WGRHIFL == "Y")
 
 var_labels(adlb_f) <- adlb_labels
 
@@ -40,14 +38,15 @@ adlb_f <- adlb_f %>%
   mutate(
     GRADE_DIR = factor(
       case_when(
-        ATOXGR %in% c("-1", "-2", "-3", "-4") ~ "LOW",
+        ATOXGR %in% c("-1", "-2", "-3", "-4") & .data$WGRLOFL == "Y" ~ "LOW",
         ATOXGR == "0" ~ "ZERO",
-        ATOXGR %in% c("1", "2", "3", "4") ~ "HIGH"
+        ATOXGR %in% c("1", "2", "3", "4") & .data$WGRHIFL == "Y" ~ "HIGH",
+        TRUE ~ "NONE"
       ),
-      levels = c("LOW", "ZERO", "HIGH")
+      levels = c("LOW", "ZERO", "HIGH", "NONE")
     ),
-    GRADE_ANL = fct_relevel(
-      fct_recode(ATOXGR,
+    GRADE_ANL = forcats::fct_relevel(
+      forcats::fct_recode(ATOXGR,
         `1` = "-1", `2` = "-2", `3` = "-3", `4` = "-4"
       ),
       c("0", "1", "2", "3", "4")
@@ -59,17 +58,20 @@ adlb_f <- adlb_f %>%
   )
 
 # Construct analysis map
-map <- unique(adlb_f[adlb_f$GRADE_DIR != "ZERO", c("PARAM", "GRADE_DIR", "GRADE_ANL")]) %>%
-  lapply(as.character) %>%
-  as.data.frame() %>%
-  arrange(PARAM, desc(GRADE_DIR), GRADE_ANL)
+map <- expand.grid(
+    PARAM = levels(adlb$PARAM),
+    GRADE_DIR = c("LOW", "HIGH"),
+    GRADE_ANL = as.character(1:4),
+    stringsAsFactors = FALSE
+  ) %>%
+    arrange(PARAM, desc(GRADE_DIR), GRADE_ANL)
 ```
 
 ## Standard Table
 
 ```{r variant 1}
 lyt <- basic_table(show_colcounts = TRUE) %>%
-  split_cols_by("ARMCD") %>%
+  split_cols_by("ACTARM") %>%
   split_rows_by(
     "PARAM",
     label_pos = "topleft",
@@ -91,13 +93,10 @@ lyt <- basic_table(show_colcounts = TRUE) %>%
     variables = list(id = "USUBJID", param = "PARAM", grade_dir = "GRADE_DIR"),
     .indent_mods = 4L
   ) %>%
-  append_topleft("    Highest NCI CTCAE Grade")
+  append_topleft("            Highest NCI CTCAE Grade")
 
-result <- build_table(
-  lyt = lyt,
-  df = adlb_f,
-  alt_counts_df = adsl
-)
+result <- build_table(lyt = lyt, df = adlb_f, alt_counts_df = adsl)
+result <- result %>% prune_table()
 
 result
 ```
@@ -151,5 +150,4 @@ shinyApp(app$ui, app$server)
 ```
 
 {{< include ../../si.qmd >}}
-
 :::

--- a/tables/lab-results/lbt14.qmd
+++ b/tables/lab-results/lbt14.qmd
@@ -29,7 +29,7 @@ adlb <- df_explicit_na(adlb)
 # Please note that in real clinical data, population flag like SAFFL, and parameter category like PARCAT2 needs to be
 # selected properly.
 adsl_f <- adsl %>% filter(SAFFL == "Y")
-adlb <- adlb %>% filter(PARAMCD == "CRP" & SAFFL == "Y")
+adlb <- adlb %>% filter(SAFFL == "Y")
 ```
 
 ## Standard Table (High)
@@ -46,52 +46,45 @@ adlb_out <- h_adsl_adlb_merge_using_worst_flag(adsl_f, adlb_f, worst_flag = c("W
 # Create new grouping variables ATOXGR_GP, BTOXGR_GP
 adlb_out <- adlb_out %>%
   mutate(
-    ATOXGR_GP = case_when(
+    ATOXGR_GP = factor(case_when(
       ATOXGR %in% c(0, -1, -2, -3, -4) ~ "Not High",
       ATOXGR == 1 ~ "1",
       ATOXGR == 2 ~ "2",
       ATOXGR == 3 ~ "3",
       ATOXGR == 4 ~ "4",
       ATOXGR == "<Missing>" ~ "Missing"
-    )
+    ), levels = c("Not High", "1", "2", "3", "4", "Missing"))
   ) %>%
   mutate(
-    BTOXGR_GP = case_when(
+    BTOXGR_GP = factor(case_when(
       BTOXGR %in% c(0, -1, -2, -3, -4) ~ "Not High",
       BTOXGR == 1 ~ "1",
       BTOXGR == 2 ~ "2",
       BTOXGR == 3 ~ "3",
       BTOXGR == 4 ~ "4",
       BTOXGR == "<Missing>" ~ "Missing"
-    )
-  )
-
-adlb_out <- adlb_out %>% mutate(
-  ATOXGR_GP = factor(ATOXGR_GP, levels = c("Not High", "1", "2", "3", "4", "Missing")),
-  BTOXGR_GP = factor(BTOXGR_GP, levels = c("Not High", "1", "2", "3", "4", "Missing"))
-)
-
-adlb_out <- adlb_out %>%
-  var_relabel(
-    PARAMCD = "Parameter Code",
-    ATOXGR_GP = "Post-baseline NCI CTCAE Grade",
-    BTOXGR_GP = "Baseline NCI CTCAE Grade"
+    ), levels = c("Not High", "1", "2", "3", "4", "Missing"))
   )
 
 result <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by("ACTARM") %>%
   split_rows_by(
-    "PARAMCD",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$PARAMCD)
+    "PARAM",
+    split_fun = drop_split_levels,
+    label_pos = "topleft", 
+    split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$BTOXGR_GP)
+    label_pos = "topleft", 
+    split_label = "    Baseline NCI-CTCAE Grade",
+    indent_mod = 2L
   ) %>%
-  summarize_num_patients(var = "USUBJID", .stats = c("unique_count")) %>%
-  count_occurrences("ATOXGR_GP", denom = "n", drop = TRUE, .indent_mods = 4L) %>%
-  append_varlabels(adlb_out, "ATOXGR_GP", indent = 2L) %>%
-  build_table(df = adlb_out, alt_counts_df = adsl_f)
+  summarize_num_patients(var = "USUBJID", .stats = c("unique_count"), unique_count_suffix = FALSE) %>%
+  count_occurrences_by_grade("ATOXGR_GP", denom = "n", drop = FALSE, .indent_mods = 3L) %>%
+  append_topleft("              Post-baseline NCI-CTCAE Grade") %>%
+  build_table(df = adlb_out, alt_counts_df = adsl_f) %>%
+  prune_table()
 
 result
 ```
@@ -110,52 +103,45 @@ adlb_out <- h_adsl_adlb_merge_using_worst_flag(adsl_f, adlb_f, worst_flag = c("W
 # Create new grouping variables ATOXGR_GP, BTOXGR_GP
 adlb_out <- adlb_out %>%
   mutate(
-    ATOXGR_GP = case_when(
+    ATOXGR_GP = factor(case_when(
       ATOXGR %in% c(0, 1, 2, 3, 4) ~ "Not Low",
       ATOXGR == -1 ~ "1",
       ATOXGR == -2 ~ "2",
       ATOXGR == -3 ~ "3",
       ATOXGR == -4 ~ "4",
       ATOXGR == "<Missing>" ~ "Missing"
-    )
+    ), levels = c("Not Low", "1", "2", "3", "4", "Missing"))
   ) %>%
   mutate(
-    BTOXGR_GP = case_when(
+    BTOXGR_GP = factor(case_when(
       BTOXGR %in% c(0, 1, 2, 3, 4) ~ "Not Low",
       BTOXGR == -1 ~ "1",
       BTOXGR == -2 ~ "2",
       BTOXGR == -3 ~ "3",
       BTOXGR == -4 ~ "4",
       BTOXGR == "<Missing>" ~ "Missing"
-    )
-  )
-
-adlb_out <- adlb_out %>% mutate(
-  ATOXGR_GP = factor(ATOXGR_GP, levels = c("Not Low", "1", "2", "3", "4", "Missing")),
-  BTOXGR_GP = factor(BTOXGR_GP, levels = c("Not Low", "1", "2", "3", "4", "Missing"))
-)
-
-adlb_out <- adlb_out %>%
-  var_relabel(
-    PARAMCD = "Parameter Code",
-    ATOXGR_GP = "Post-baseline NCI CTCAE Grade",
-    BTOXGR_GP = "Baseline NCI CTCAE Grade"
+    ), levels = c("Not Low", "1", "2", "3", "4", "Missing"))
   )
 
 result <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by("ACTARM") %>%
   split_rows_by(
-    "PARAMCD",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$PARAMCD)
+    "PARAM",
+    split_fun = drop_split_levels,
+    label_pos = "topleft", 
+    split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$BTOXGR_GP)
+    label_pos = "topleft", 
+    split_label = "    Baseline NCI-CTCAE Grade",
+    indent_mod = 2L
   ) %>%
-  summarize_num_patients(var = "USUBJID", .stats = c("unique_count")) %>%
-  count_occurrences("ATOXGR_GP", denom = "n", drop = TRUE, .indent_mods = 4L) %>%
-  append_varlabels(adlb_out, "ATOXGR_GP", indent = 2L) %>%
-  build_table(df = adlb_out, alt_counts_df = adsl_f)
+  summarize_num_patients(var = "USUBJID", .stats = c("unique_count"), unique_count_suffix = FALSE) %>%
+  count_occurrences_by_grade("ATOXGR_GP", denom = "n", drop = FALSE, .indent_mods = 3L) %>%
+  append_topleft("              Post-baseline NCI-CTCAE Grade") %>%
+  build_table(df = adlb_out, alt_counts_df = adsl_f) %>%
+  prune_table()
 
 result
 ```
@@ -174,58 +160,51 @@ adlb_out <- h_adsl_adlb_merge_using_worst_flag(adsl_f, adlb_f, worst_flag = c("W
 adlb_out <- adlb_out %>%
   filter(BTOXGR != "<Missing>") %>%
   mutate(
-    ATOXGR_GP = case_when(
+    ATOXGR_GP = factor(case_when(
       ATOXGR %in% c(0, -1, -2, -3, -4) ~ "Not High",
       ATOXGR == 1 ~ "1",
       ATOXGR == 2 ~ "2",
       ATOXGR == 3 ~ "3",
       ATOXGR == 4 ~ "4",
       ATOXGR == "<Missing>" ~ "Missing"
-    )
+    ), levels = c("Not High", "1", "2", "3", "4", "Missing"))
   ) %>%
   mutate(
-    BTOXGR_GP = case_when(
+    BTOXGR_GP = factor(case_when(
       BTOXGR %in% c(0, -1, -2, -3, -4) ~ "Not High",
       BTOXGR == 1 ~ "1",
       BTOXGR == 2 ~ "2",
       BTOXGR == 3 ~ "3",
       BTOXGR == 4 ~ "4"
-    )
-  )
-
-adlb_out <- adlb_out %>% mutate(
-  ATOXGR_GP = factor(ATOXGR_GP, levels = c("Not High", "1", "2", "3", "4", "Missing")),
-  BTOXGR_GP = factor(BTOXGR_GP, levels = c("Not High", "1", "2", "3", "4"))
-)
-
-adlb_out <- adlb_out %>%
-  var_relabel(
-    PARAMCD = "Parameter Code",
-    ATOXGR_GP = "Post-baseline NCI CTCAE Grade",
-    BTOXGR_GP = "Baseline NCI CTCAE Grade"
+    ), levels = c("Not High", "1", "2", "3", "4"))
   )
 
 result <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by("ACTARM") %>%
   split_rows_by(
-    "PARAMCD",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$PARAMCD)
+    "PARAM",
+    split_fun = drop_split_levels,
+    label_pos = "topleft", 
+    split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$BTOXGR_GP)
+    label_pos = "topleft", 
+    split_label = "    Baseline NCI-CTCAE Grade",
+    indent_mod = 2L
   ) %>%
-  summarize_num_patients(var = "USUBJID", .stats = c("unique_count")) %>%
-  count_occurrences("ATOXGR_GP", denom = "n", drop = TRUE, .indent_mods = 4L) %>%
-  append_varlabels(adlb_out, "ATOXGR_GP", indent = 2L) %>%
-  build_table(df = adlb_out, alt_counts_df = adsl_f)
+  summarize_num_patients(var = "USUBJID", .stats = c("unique_count"), unique_count_suffix = FALSE) %>%
+  count_occurrences_by_grade("ATOXGR_GP", denom = "n", drop = FALSE, .indent_mods = 3L) %>%
+  append_topleft("              Post-baseline NCI-CTCAE Grade") %>%
+  build_table(df = adlb_out, alt_counts_df = adsl_f) %>%
+  prune_table()
 
 result
 ```
 
 ## Table with Missing Baseline <br/> Considered as Grade 0 (Low)
 
-Note that when BTOXGR is missing, the grouping variable `BTOXGR_GP` now is `"Not Low"` instead of `"Missing"` compared to *Standard Table (High)*.
+Note that when BTOXGR is missing, the grouping variable `BTOXGR_GP` now is `"Not Low"` instead of `"Missing"` compared to *Standard Table (Low)*.
 
 ```{r variant4}
 adlb_f <- adlb %>% filter(WGRLOFL == "Y")
@@ -236,58 +215,51 @@ adlb_out <- h_adsl_adlb_merge_using_worst_flag(adsl_f, adlb_f, worst_flag = c("W
 # Create new grouping variables ATOXGR_GP, BTOXGR_GP
 adlb_out <- adlb_out %>%
   mutate(
-    ATOXGR_GP = case_when(
+    ATOXGR_GP = factor(case_when(
       ATOXGR %in% c(0, 1, 2, 3, 4) ~ "Not Low",
       ATOXGR == -1 ~ "1",
       ATOXGR == -2 ~ "2",
       ATOXGR == -3 ~ "3",
       ATOXGR == -4 ~ "4",
       ATOXGR == "<Missing>" ~ "Missing"
-    )
+    ), levels = c("Not Low", "1", "2", "3", "4"))
   ) %>%
   mutate(
-    BTOXGR_GP = case_when(
+    BTOXGR_GP = factor(case_when(
       BTOXGR %in% c(0, 1, 2, 3, 4, "<Missing>") ~ "Not Low",
       BTOXGR == -1 ~ "1",
       BTOXGR == -2 ~ "2",
       BTOXGR == -3 ~ "3",
       BTOXGR == -4 ~ "4"
-    )
-  )
-
-adlb_out <- adlb_out %>% mutate(
-  ATOXGR_GP = factor(ATOXGR_GP, levels = c("Not Low", "1", "2", "3", "4", "Missing")),
-  BTOXGR_GP = factor(BTOXGR_GP, levels = c("Not Low", "1", "2", "3", "4"))
-)
-
-adlb_out <- adlb_out %>%
-  var_relabel(
-    PARAMCD = "Parameter Code",
-    ATOXGR_GP = "Post-baseline NCI CTCAE Grade",
-    BTOXGR_GP = "Baseline NCI CTCAE Grade"
+    ), levels = c("Not Low", "1", "2", "3", "4", "Missing"))
   )
 
 result <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by("ACTARM") %>%
   split_rows_by(
-    "PARAMCD",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$PARAMCD)
+    "PARAM",
+    split_fun = drop_split_levels,
+    label_pos = "topleft", 
+    split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$BTOXGR_GP)
+    label_pos = "topleft", 
+    split_label = "    Baseline NCI-CTCAE Grade",
+    indent_mod = 2L
   ) %>%
-  summarize_num_patients(var = "USUBJID", .stats = c("unique_count")) %>%
-  count_occurrences("ATOXGR_GP", denom = "n", drop = TRUE, .indent_mods = 4L) %>%
-  append_varlabels(adlb_out, "ATOXGR_GP", indent = 2L) %>%
-  build_table(df = adlb_out, alt_counts_df = adsl_f)
+  summarize_num_patients(var = "USUBJID", .stats = c("unique_count"), unique_count_suffix = FALSE) %>%
+  count_occurrences_by_grade("ATOXGR_GP", denom = "n", drop = FALSE, .indent_mods = 3L) %>%
+  append_topleft("              Post-baseline NCI-CTCAE Grade") %>%
+  build_table(df = adlb_out, alt_counts_df = adsl_f) %>%
+  prune_table()
 
 result
 ```
 
 ## Table with Fill-In of Grades
 
-Pre-processing is the same as *Standard Table (High)*, but in order to keep all levels, the `drop` argument in `count_occurrences` is set to `FALSE`.
+Pre-processing is the same as *Standard Table (High)*, but in order to keep all levels, `prune_table()` is not applied.
 
 ```{r variant5}
 adlb_f <- adlb %>% filter(WGRHIFL == "Y")
@@ -298,53 +270,43 @@ adlb_out <- h_adsl_adlb_merge_using_worst_flag(adsl_f, adlb_f, worst_flag = c("W
 # Create new grouping variables ATOXGR_GP, BTOXGR_GP
 adlb_out <- adlb_out %>%
   mutate(
-    ATOXGR_GP = case_when(
+    ATOXGR_GP = factor(case_when(
       ATOXGR %in% c(0, -1, -2, -3, -4) ~ "Not High",
       ATOXGR == 1 ~ "1",
       ATOXGR == 2 ~ "2",
       ATOXGR == 3 ~ "3",
       ATOXGR == 4 ~ "4",
       ATOXGR == "<Missing>" ~ "Missing"
-    )
+    ), levels = c("Not High", "1", "2", "3", "4", "Missing"))
   ) %>%
   mutate(
-    BTOXGR_GP = case_when(
+    BTOXGR_GP = factor(case_when(
       BTOXGR %in% c(0, -1, -2, -3, -4) ~ "Not High",
       BTOXGR == 1 ~ "1",
       BTOXGR == 2 ~ "2",
       BTOXGR == 3 ~ "3",
       BTOXGR == 4 ~ "4",
       BTOXGR == "<Missing>" ~ "Missing"
-    )
-  )
-
-adlb_out <- adlb_out %>% mutate(
-  ATOXGR_GP = factor(ATOXGR_GP, levels = c("Not High", "1", "2", "3", "4", "Missing")),
-  BTOXGR_GP = factor(BTOXGR_GP, levels = c("Not High", "1", "2", "3", "4", "Missing"))
-)
-
-adlb_out <- adlb_out %>%
-  var_relabel(
-    PARAMCD = "Parameter Code",
-    ATOXGR_GP = "Post-baseline NCI CTCAE Grade",
-    BTOXGR_GP = "Baseline NCI CTCAE Grade"
+    ), levels = c("Not High", "1", "2", "3", "4", "Missing"))
   )
 
 result <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by("ACTARM") %>%
   split_rows_by(
-    "PARAMCD",
-    split_fun = drop_split_levels, label_pos = "topleft", split_label = obj_label(adlb_out$PARAMCD)
+    "PARAM",
+    split_fun = drop_split_levels,
+    label_pos = "topleft", 
+    split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    split_fun = keep_split_levels(c("Not High", "1", "2", "3", "4", "Missing")),
-    label_pos = "topleft",
-    split_label = obj_label(adlb_out$BTOXGR_GP)
+    label_pos = "topleft", 
+    split_label = "    Baseline NCI-CTCAE Grade",
+    indent_mod = 2L
   ) %>%
-  summarize_num_patients(var = "USUBJID", .stats = c("unique_count")) %>%
-  count_occurrences("ATOXGR_GP", denom = "n", drop = FALSE, .indent_mods = 4L) %>%
-  append_varlabels(adlb_out, "ATOXGR_GP", indent = 2L) %>%
+  summarize_num_patients(var = "USUBJID", .stats = c("unique_count"), unique_count_suffix = FALSE) %>%
+  count_occurrences_by_grade("ATOXGR_GP", denom = "n", drop = FALSE, .indent_mods = 3L) %>%
+  append_topleft("              Post-baseline NCI-CTCAE Grade") %>%
   build_table(df = adlb_out, alt_counts_df = adsl_f)
 
 result
@@ -412,5 +374,4 @@ shinyApp(app$ui, app$server)
 ```
 
 {{< include ../../si.qmd >}}
-
 :::

--- a/tables/lab-results/lbt14.qmd
+++ b/tables/lab-results/lbt14.qmd
@@ -71,12 +71,12 @@ result <- basic_table(show_colcounts = TRUE) %>%
   split_rows_by(
     "PARAM",
     split_fun = drop_split_levels,
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "    Baseline NCI-CTCAE Grade",
     indent_mod = 2L
   ) %>%
@@ -128,12 +128,12 @@ result <- basic_table(show_colcounts = TRUE) %>%
   split_rows_by(
     "PARAM",
     split_fun = drop_split_levels,
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "    Baseline NCI-CTCAE Grade",
     indent_mod = 2L
   ) %>%
@@ -184,12 +184,12 @@ result <- basic_table(show_colcounts = TRUE) %>%
   split_rows_by(
     "PARAM",
     split_fun = drop_split_levels,
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "    Baseline NCI-CTCAE Grade",
     indent_mod = 2L
   ) %>%
@@ -239,12 +239,12 @@ result <- basic_table(show_colcounts = TRUE) %>%
   split_rows_by(
     "PARAM",
     split_fun = drop_split_levels,
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "    Baseline NCI-CTCAE Grade",
     indent_mod = 2L
   ) %>%
@@ -295,12 +295,12 @@ result <- basic_table(show_colcounts = TRUE) %>%
   split_rows_by(
     "PARAM",
     split_fun = drop_split_levels,
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "Parameter"
   ) %>%
   split_rows_by(
     "BTOXGR_GP",
-    label_pos = "topleft", 
+    label_pos = "topleft",
     split_label = "    Baseline NCI-CTCAE Grade",
     indent_mod = 2L
   ) %>%


### PR DESCRIPTION
Closes #58 

Notes: 

- Did not change precision in LBT01/CFBT01
- No `PARCAT2` variable to filter by in LBT04
- No `A*` variables in data - only `AE*` variables used (e.g. `AETOXGR` vs. `ATOXGR`)