### PR TITLE
#74 (PR 6/12) - Adding snapshots for tables/pharmacokinetic

### DIFF
--- a/book/tables/pharmacokinetic/adat01.qmd
+++ b/book/tables/pharmacokinetic/adat01.qmd
@@ -220,7 +220,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/adat01.qmd
+++ b/book/tables/pharmacokinetic/adat01.qmd
@@ -5,6 +5,8 @@ subtitle: Baseline Prevalence and Incidence of Treatment Emergent ADA
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -108,7 +110,7 @@ adab_pb <- df_explicit_na(adab) %>%
 
 ## Standard Table
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # Layout for Baseline Prevalence of NAbs
 lyt_bl <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by(
@@ -213,6 +215,8 @@ main_footer(result) <- paste(
 )
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/adat02.qmd
+++ b/book/tables/pharmacokinetic/adat02.qmd
@@ -5,6 +5,8 @@ subtitle: Summary of Patients with Treatment-Induced ADA
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -61,7 +63,7 @@ adab_ti <- adab %>%
 
 ## Standard Table
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # Layout for post-baseline evaluable patient variables from adab dataset.
 lyt_adab <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by(
@@ -134,6 +136,8 @@ main_footer(result) <- paste(
 )
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/adat02.qmd
+++ b/book/tables/pharmacokinetic/adat02.qmd
@@ -141,7 +141,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/adat03.qmd
+++ b/book/tables/pharmacokinetic/adat03.qmd
@@ -5,6 +5,8 @@ subtitle: Summary of Serum Concentrations at Timepoints Where ADA Samples Were C
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -39,7 +41,7 @@ anl <- merge(anl, adpc, by = c("USUBJID", "NFRLT")) %>%
 
 ## Standard Table (μg/mL)
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # parameters in columns
 adat03_stats <- c("n", "mean", "sd", "median", "min", "max", "cv", "geom_mean", "count_fraction")
 adat03_lbls <- c(
@@ -112,6 +114,8 @@ or Anti-Therapeutic Antibodies). RXXXXXXX is also known as [drug]"
 
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/adat03.qmd
+++ b/book/tables/pharmacokinetic/adat03.qmd
@@ -119,7 +119,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/adat04a.qmd
+++ b/book/tables/pharmacokinetic/adat04a.qmd
@@ -230,7 +230,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/adat04a.qmd
+++ b/book/tables/pharmacokinetic/adat04a.qmd
@@ -5,6 +5,8 @@ subtitle: Baseline Prevalence and Incidence of Treatment Emergent NAbs
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -119,7 +121,7 @@ adab_pb <- df_explicit_na(adab) %>%
 
 ## Summary of Treatment Emergent NAbs
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # Layout for Baseline Prevalence of NAbs
 lyt_bl <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by(
@@ -223,6 +225,8 @@ Treatment unaffected = A post-baseline evaluable patient with a positive result 
 )
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/adat04b.qmd
+++ b/book/tables/pharmacokinetic/adat04b.qmd
@@ -213,7 +213,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/adat04b.qmd
+++ b/book/tables/pharmacokinetic/adat04b.qmd
@@ -5,6 +5,8 @@ subtitle: Baseline Prevalence and Incidence of NAbs
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -123,7 +125,7 @@ adab_pb <- left_join(adab_pb_ada, adab_pb_adap, by = mergecol) %>%
 
 ## Standard Table
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # Layout for Baseline Prevalence of NAbs
 lyt_bl <- basic_table(show_colcounts = TRUE) %>%
   split_cols_by(
@@ -206,6 +208,8 @@ Number of patients positive for NAb = the number (and percentage) of post-baseli
 )
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkct01.qmd
+++ b/book/tables/pharmacokinetic/pkct01.qmd
@@ -104,7 +104,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkct01.qmd
+++ b/book/tables/pharmacokinetic/pkct01.qmd
@@ -5,6 +5,8 @@ subtitle: Summary Concentration Table
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -25,7 +27,7 @@ threesigfmt <- function(x, ...) {
 
 ## Standard Table (Stats in Columns)
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # Setting up the data
 adpc_1 <- adpc %>%
   mutate(
@@ -97,6 +99,8 @@ subtitles(result) <- paste("Analyte: ", unique(unique(adpc$PARAM)), "Treatment:"
 main_footer(result) <- "NE: Not Estimable"
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt02.qmd
+++ b/book/tables/pharmacokinetic/pkpt02.qmd
@@ -86,7 +86,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt02.qmd
+++ b/book/tables/pharmacokinetic/pkpt02.qmd
@@ -5,6 +5,8 @@ subtitle: Pharmacokinetic Parameter Summary -- Plasma/Serum/Blood PK Parameters 
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -52,7 +54,7 @@ lyt <- basic_table() %>%
 
 #### Plasma Drug X
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 adpp0 <- adpp %>%
   filter(PPCAT == "Plasma Drug X") %>%
   h_pkparam_sort() %>%
@@ -67,7 +69,7 @@ result
 
 #### Plasma Drug Y
 
-```{r}
+```{r variant2, test = list(result_v2 = "result")}
 adpp1 <- adpp %>%
   filter(PPCAT == "Plasma Drug Y") %>%
   h_pkparam_sort() %>%
@@ -79,6 +81,8 @@ main_title(result) <- paste("Summary of", unique(adpp1$PPSPEC), "PK Parameter by
 subtitles(result) <- paste("Analyte:", unique(adpp1$PPCAT), "\nVisit:", unique(adpp1$AVISIT))
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt03.qmd
+++ b/book/tables/pharmacokinetic/pkpt03.qmd
@@ -103,7 +103,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt03.qmd
+++ b/book/tables/pharmacokinetic/pkpt03.qmd
@@ -5,6 +5,8 @@ subtitle: Pharmacokinetic Parameter Summary of Plasma by Treatment (Stats in Col
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -69,7 +71,7 @@ lyt <- basic_table() %>%
 
 #### Plasma Drug X
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 adpp0 <- adpp %>%
   filter(PPCAT == "Plasma Drug X") %>%
   h_pkparam_sort() %>%
@@ -84,7 +86,7 @@ result
 
 #### Plasma Drug Y
 
-```{r}
+```{r variant2, test = list(result_v2 = "result")}
 adpp1 <- adpp %>%
   filter(PPCAT == "Plasma Drug Y") %>%
   h_pkparam_sort() %>%
@@ -96,6 +98,8 @@ main_title(result) <- paste("Summary of", unique(adpp1$PPSPEC), "PK Parameter by
 subtitles(result) <- paste("Analyte:", unique(adpp1$PPCAT), "\nVisit:", unique(adpp1$AVISIT))
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt04.qmd
+++ b/book/tables/pharmacokinetic/pkpt04.qmd
@@ -86,7 +86,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt04.qmd
+++ b/book/tables/pharmacokinetic/pkpt04.qmd
@@ -5,6 +5,8 @@ subtitle: Pharmacokinetic Parameter Summary -- Urine PK Parameters (Stats in Row
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -52,7 +54,7 @@ lyt <- basic_table() %>%
 
 #### Plasma Drug X
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 adpp0 <- adpp %>%
   filter(PPCAT == "Plasma Drug X") %>%
   h_pkparam_sort() %>%
@@ -67,7 +69,7 @@ result
 
 #### Plasma Drug Y
 
-```{r}
+```{r variant2, test = list(result_v2 = "result")}
 adpp1 <- adpp %>%
   filter(PPCAT == "Plasma Drug Y") %>%
   h_pkparam_sort() %>%
@@ -79,6 +81,8 @@ main_title(result) <- paste("Summary of", unique(adpp1$PPSPEC), "PK Parameter by
 subtitles(result) <- paste("Analyte:", unique(adpp1$PPCAT), "\nVisit:", unique(adpp1$AVISIT))
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt05.qmd
+++ b/book/tables/pharmacokinetic/pkpt05.qmd
@@ -103,7 +103,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt05.qmd
+++ b/book/tables/pharmacokinetic/pkpt05.qmd
@@ -5,6 +5,8 @@ subtitle: Summary of Urinary PK Parameters by Treatment Arm (Stats in Columns)
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -69,7 +71,7 @@ lyt <- basic_table() %>%
 
 #### Plasma Drug X
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 adpp0 <- adpp %>%
   filter(PPCAT == "Plasma Drug X") %>%
   h_pkparam_sort() %>%
@@ -84,7 +86,7 @@ result
 
 #### Plasma Drug Y
 
-```{r}
+```{r variant2, test = list(result_v2 = "result")}
 adpp1 <- adpp %>%
   filter(PPCAT == "Plasma Drug Y") %>%
   h_pkparam_sort() %>%
@@ -96,6 +98,8 @@ main_title(result) <- paste("Summary of", unique(adpp1$PPSPEC), "PK Parameter by
 subtitles(result) <- paste("Analyte:", unique(adpp1$PPCAT), "\nVisit:", unique(adpp1$AVISIT))
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt06.qmd
+++ b/book/tables/pharmacokinetic/pkpt06.qmd
@@ -5,6 +5,8 @@ subtitle: Pharmacokinetic Parameter Summary -- Dose-Normalized PK Parameters (St
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -53,7 +55,7 @@ lyt <- basic_table() %>%
 
 #### Plasma Drug X
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 adpp0 <- adpp %>%
   filter(PPCAT == "Plasma Drug X") %>%
   h_pkparam_sort() %>%
@@ -68,7 +70,7 @@ result
 
 #### Plasma Drug Y
 
-```{r}
+```{r variant2, test = list(result_v2 = "result")}
 adpp1 <- adpp %>%
   filter(PPCAT == "Plasma Drug Y") %>%
   h_pkparam_sort() %>%
@@ -80,6 +82,8 @@ main_title(result) <- paste("Summary of Dose-Normalized PK Parameter by Treatmen
 subtitles(result) <- paste("Analyte:", unique(adpp1$PPCAT), "\nVisit:", unique(adpp1$AVISIT))
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt06.qmd
+++ b/book/tables/pharmacokinetic/pkpt06.qmd
@@ -87,7 +87,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt07.qmd
+++ b/book/tables/pharmacokinetic/pkpt07.qmd
@@ -5,6 +5,8 @@ subtitle: Table of Mean Dose-Normalized Selected Pharmacokinetic Parameters (Sta
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -70,7 +72,7 @@ lyt <- basic_table() %>%
 
 #### Plasma Drug X
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 adpp0 <- adpp %>%
   filter(PPCAT == "Plasma Drug X") %>%
   h_pkparam_sort() %>%
@@ -85,7 +87,7 @@ result
 
 #### Plasma Drug Y
 
-```{r}
+```{r variant2, test = list(result_v2 = "result")}
 adpp1 <- adpp %>%
   filter(PPCAT == "Plasma Drug Y") %>%
   h_pkparam_sort() %>%
@@ -97,6 +99,8 @@ main_title(result) <- paste("Summary of", unique(adpp1$PPSPEC), "PK Parameter by
 subtitles(result) <- paste("Analyte:", unique(adpp1$PPCAT), "\nVisit:", unique(adpp1$AVISIT))
 result
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt07.qmd
+++ b/book/tables/pharmacokinetic/pkpt07.qmd
@@ -104,7 +104,7 @@ result
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt08.qmd
+++ b/book/tables/pharmacokinetic/pkpt08.qmd
@@ -5,6 +5,8 @@ subtitle: Pharmacokinetic Parameter Summary of Cumulative Amount of Drug Elimina
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -24,7 +26,7 @@ adpp <- adpp %>%
 
 ## Standard Table -- Plasma
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # create layout
 lyt <- basic_table() %>%
   add_overall_col("Accumulation Interval (hours)") %>%
@@ -82,6 +84,8 @@ subtitles(result) <- paste("Analyte:", unique(adpp0$PPCAT), "\nVisit:", unique(a
 
 cat(rtables::toString(result, indent_size = 10))
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/book/tables/pharmacokinetic/pkpt08.qmd
+++ b/book/tables/pharmacokinetic/pkpt08.qmd
@@ -89,7 +89,7 @@ cat(rtables::toString(result, indent_size = 10))
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt11.qmd
+++ b/book/tables/pharmacokinetic/pkpt11.qmd
@@ -152,7 +152,7 @@ cat(rtables::toString(result, indent_size = 24))
 
 ## Teal
 
-```{r teal, message=FALSE}
+```{r teal, message=FALSE, opts.label='skip_if_testing'}
 #| code-fold: show
 
 # In progress

--- a/book/tables/pharmacokinetic/pkpt11.qmd
+++ b/book/tables/pharmacokinetic/pkpt11.qmd
@@ -5,6 +5,8 @@ subtitle: Pharmacokinetic Parameter Estimated Ratios of Geometric Means and 90% 
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -44,7 +46,7 @@ formats <- c(
 
 ## Standard Table -- Plasma
 
-```{r}
+```{r variant1, test = list(result_v1 = "result")}
 # summary function
 # compare_dose - comparator, defaults to comp_dose defined above (string)
 # denom - use comparator as denominator, defaults to TRUE (logical)
@@ -145,6 +147,8 @@ subtitles(result) <- paste("Analyte:", unique(adpp0$PPCAT))
 
 cat(rtables::toString(result, indent_size = 24))
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 ## Teal
 

--- a/package/tests/testthat/_snaps/adat01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/adat01/markdown-snaps.md
@@ -1,0 +1,33 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Baseline Prevalence and Incidence of Treatment Emergent ADA
+      
+      —————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+                                                     A: Drug X    C: Combination   <Missing>   B: Placebo   All Drug X 
+                                                      (N=134)        (N=132)         (N=0)      (N=134)       (N=266)  
+      —————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Baseline Prevalence of ADAs                                                                                      
+        Baseline evaluable patients                     134            132             0           0            266    
+      Patient with a positive sample at baseline     63 (47.0%)     64 (48.5%)        NA           NA       127 (47.7%)
+      Patient with no positive samples at baseline       71             68             0           0            139    
+      Incidence of Treatment Emergent ADAs                                                                             
+        Post-baseline evaluable patients                134            132             0           0            266    
+      Patient positive for Treatment Emergent ADA        0              0             NA           NA            0     
+      Treatment-induced ADA                              0              0              0           0             0     
+      Treatment-enhanced ADA                             0              0              0           0             0     
+      Patient negative for Treatment Emergent ADA        0              0             NA           NA            0     
+      Treatment unaffected                               0              0              0           0             0     
+      —————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      
+      ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies) Baseline evaluable patient = a patient with an ADA assay result from a baseline sample(s)
+        Post-baseline evaluable patient = a patient with an ADA assay result from at least one post-baseline sample Number of patients positive for Treatment Emergent
+        ADA = the number (and percentage) of post-baseline evaluable patients determined to have treatment-induced ADA or treatment-enhanced ADA during the study period.
+        Treatment-induced ADA = a patient with negative or missing baseline ADA result(s) and at least one positive post-baseline ADA result.
+        Treatment-enhanced ADA = a patient with positive ADA result at baseline who has one or more post-baseline titer results that are at least 0.60 t.u. greater than the baseline titer result.
+        Number of patients negative for Treatment Emergent ADA = number of post-baseline evaluable patients with negative or missing baseline ADA result(s) and all negative post-baseline results, or a patient who is treatment unaffected.
+        Treatment unaffected = A post-baseline evaluable patient with a positive ADA result at baseline and (a) where all post-baseline titer results are less than 0.60 t.u. greater than the baseline titer result, OR (b) where all post-baseline results are negative or missing.
+        For any positive sample with titer result less than the minimum reportable titer or any positive sample where a titer cannot be obtained, titer value is imputed as equal to the minimum reportable titer.
+

--- a/package/tests/testthat/_snaps/adat02/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/adat02/markdown-snaps.md
@@ -1,0 +1,34 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Patients with Treatment-Induced ADA, PK Population
+      Protocol: A: Drug X Antibody
+      
+      —————————————————————————————————————————————————————————————————————————————
+                                            A: Drug X   C: Combination   <Missing> 
+                                             (N=134)       (N=132)         (N=0)   
+      —————————————————————————————————————————————————————————————————————————————
+      Post-baseline evaluable patients         134           132            266    
+      Treatment-induced ADA patients            0             0          64 (24.1%)
+      Treatment-induced ADA patients with                                          
+        Transient ADA                          NA             NA             0     
+        Persistent ADA                         NA             NA             0     
+      Median time to onset of ADA (weeks)      NA             NA            0.1    
+      ADA titer range (min - max)              NA             NA             NA    
+      —————————————————————————————————————————————————————————————————————————————
+      
+      ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic
+        Antibodies)
+        Treatment-induced ADA = negative or missing baseline.
+        ADA result(s) and at least one positive post-baseline ADA result.
+        Transient ADA = ADA positive result detected (a) at only one post-baseline
+        sampling timepoint (excluding last timepoint) OR (b) at 2 or more timepoints
+        during treatment where the first and last ADA positive samples are separated
+        by a period of < 16 weeks, irrespective of any negative samples in between.
+        Persistent ADA = ADA positive result detected (a) at the last post-baseline
+        sampling timepoint, OR (b) at 2 or more time points during treatment where
+        the first and last ADA positive samples are separated by a period ≥ 16
+        weeks, irrespective of any negative samples in between.
+

--- a/package/tests/testthat/_snaps/adat03/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/adat03/markdown-snaps.md
@@ -1,0 +1,43 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Serum Concentrations (μg/mL) at Timepoints Where ADA Samples Were Collected and Analyzed
+      
+        Protocol: A: Drug X Antibody
+      Analyte: R1800000
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Treatment Group                                                                                                                             
+        Visit                  Total Number                                                                                          Samples with 
+                               of Measurable                                                                                         Concentration
+                                Samples {1}      Mean         SD        Median      Minimum     Maximum    CV (%)   Geometric Mean   ≤ 15μg/mL {2}
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      A: Drug X (N=536)                                                                                                                           
+        Day 1                                                                                                                                     
+          Day 1                     402        0.000e+00   0.000e+00   0.000e+00   0.000e+00   0.000e+00     NA           NA          402 (100%)  
+        Day 2                                                                                                                                     
+          Day 2                     134        1.618e+01   1.626e+00   1.619e+01   1.260e+01   1.986e+01    10.0      1.610e+01       39 (29.1%)  
+        <Missing>                                                                                                                                 
+          <Missing>                  0            NA          NA          NA          NA          NA         NA           NA              NA      
+      
+      C: Combination (N=792)                                                                                                                      
+        Day 1                                                                                                                                     
+          Day 1                     528        0.000e+00   0.000e+00   0.000e+00   0.000e+00   0.000e+00     NA           NA          528 (100%)  
+        Day 2                                                                                                                                     
+          Day 2                     264        2.468e+01   8.645e+00   2.251e+01   1.264e+01   3.947e+01    35.0      2.315e+01       28 (10.6%)  
+        <Missing>                                                                                                                                 
+          <Missing>                  0            NA          NA          NA          NA          NA         NA           NA              NA      
+      
+      Overall                      1328        6.540e+00   1.095e+01   0.000e+00   0.000e+00   3.947e+01   167.5          NA          997 (75.1%) 
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      
+      {1} - Refers to the total no. of measurable ADA samples that have a corresponding measurable drug concentration sample (i.e. results with
+      valid numeric values and LTRs). LTR results on post-dose samples are replaced by aaa µg/mL i.e. half of MQC value.
+      {2} - In validation, the assay was able to detect yyy ng/mL of surrogate ADA in the presence of zzz µg/mL of [drug]. BLQ = Below Limit of
+      Quantitation, LTR = Lower than Reportable, MQC = Minimum Quantifiable Concentration, ADA = Anti-Drug Antibodies (is also referred to as ATA,
+      or Anti-Therapeutic Antibodies). RXXXXXXX is also known as [drug]
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      
+

--- a/package/tests/testthat/_snaps/adat04a/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/adat04a/markdown-snaps.md
@@ -1,0 +1,37 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Baseline Prevalence and Incidence of Treatment Emergent NAbs
+      Protocol: A: Drug X Antibody
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+                                                          A: Drug X   C: Combination   <Missing>   B: Placebo   All Drug X
+                                                           (N=134)       (N=132)         (N=0)      (N=134)      (N=266)  
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Baseline Prevalence of NAbs                                                                                         
+        Baseline evaluable patients for ADA                  134           132             0           0           266    
+        Patients with a positive ADA sample at baseline      63             64             0           0           127    
+      Patients with a positive NAb sample at baseline         0             0             NA           NA           0     
+      Patient with no positive NAb samples at baseline        0             0              0           0            0     
+      Incidence of Treatment Emergent NAbs                                                                                
+        Post-baseline evaluable patients for ADA             134           132             0           0           266    
+        Patients positive for ADA                            66             59             0           0           125    
+      Patients positive for Treatment Emergent NAb            0             0             NA           NA           0     
+      Treatment-induced NAb                                   0             0              0           0            0     
+      Treatment-enhanced NAb                                  0             0              0           0            0     
+      Patients negative for NAb                               0             0             NA           NA           0     
+      Treatment unaffected                                    0             0              0           0            0     
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      
+      NAb = Neutralizing Antibodies ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies) Baseline evaluable patient for ADA = a patient with an ADA assay result from a baseline sample(s)
+        Baseline evaluable patient for NAb = a patient with a NAb assay result from a baseline sample(s)
+        Post-baseline evaluable patient for ADA = a patient with an ADA assay result from at least one post-baseline sample
+        Post-baseline evaluable patient for NAb = a patient with a NAb assay result from at least one post-baseline sample
+        Number of patients positive for ADA = the number of post-baseline evaluable patients for ADA determined to have Treatment Emergent ADA during the study period.
+      Number of patients positive for Treatment Emergent NAb = the number (and percentage) of post-baseline evaluable patients for ADA determined to have treatment-induced NAb or treatment-enhanced NAb during the study period.
+      Treatment-induced = a patient with negative or missing baseline result(s) and at least one positive post-baseline result. Treatment-enhanced = a patient with positive result at baseline who has one or more post-baseline titer results that are at least 0.60 t.u. greater than the baseline titer result.
+      Number of patients negative for Treatment Emergent NAb = number of post-baseline evaluable patients with negative or missing baseline NAb result(s) and all negative post-baseline NAb results, or a patient who is NAb treatment unaffected.
+      Treatment unaffected = A post-baseline evaluable patient with a positive result at baseline and (a) where all post-baseline titer results are less than 0.60 t.u. greater than the baseline titer result, OR (b) where all post-baseline results are negative or missing. For any positive sample with titer result less than the minimum reportable titer or any positive sample where a titer cannot be obtained, titer value is imputed as equal to the minimum reportable titer.
+

--- a/package/tests/testthat/_snaps/adat04b/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/adat04b/markdown-snaps.md
@@ -1,0 +1,27 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Baseline Prevalence and Incidence of Neutralizing Antibodies (NAbs)
+      Protocol: A: Drug X Antibody
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+                                                          A: Drug X   C: Combination   <Missing>   B: Placebo   All Drug X
+                                                           (N=134)       (N=132)         (N=0)      (N=134)      (N=266)  
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Baseline Prevalence of NAbs                                                                                         
+        Baseline evaluable patients for ADA                  134           132             0           0           266    
+        Patients with a positive ADA sample at baseline      63             64             0           0           127    
+      Patients with a positive NAb sample at baseline         0             0             NA           NA           0     
+      Patients with no positive NAb sample at baseline        0             0              0           0            0     
+      Incidence of NAbs                                                                                                   
+        Post-baseline evaluable patients for ADA             134           132             0           0           266    
+        Patients positive for ADA                            66             59             0           0           125    
+      Patients positive for NAb                               0             0             NA           NA           0     
+      Patients negative for NAb                              134           132             0           0           266    
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      
+      NAb = Neutralizing Antibodies ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies) Baseline evaluable patient for ADA = a patient with an ADA assay result from a baseline sample(s) Baseline evaluable patient for NAb = a patient with a NAb assay result from a baseline sample(s) Post-baseline evaluable patient for ADA = a patient with an ADA assay result from at least one post-baseline sample Post-baseline evaluable patient for NAb = a patient with a NAb assay result from at least one post-baseline sample Number of patients positive for ADA = the number of post-baseline evaluable patients for ADA determined to have Treatment Emergent ADA during the study period.
+      Number of patients positive for NAb = the number (and percentage) of post-baseline evaluable patients for ADA determined to have at least one positive post-baseline NAb result during the study period. Number of patients negative for NAb = number of post-baseline evaluable patients with all negative post-baseline NAb results.
+

--- a/package/tests/testthat/_snaps/pkct01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkct01/markdown-snaps.md
@@ -1,0 +1,46 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of PK Concentrations by Nominal Time and Treatment: PK Evaluable
+       Protocol: xxxxx
+      Analyte:  Plasma Drug X Treatment: A: Drug X
+      Analyte:  Urine Drug X Treatment: C: Combination
+      Analyte:  Urine Drug Y Treatment: A: Drug X
+      Analyte:  Plasma Drug Y Treatment: C: Combination
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Cohort/Treatment                                                                                                                                        
+        Visit                                                                                                                                                 
+          Norminal Time from First Dose           Number                                                                                                      
+                                                    of                                                                                                        
+                                           n    <LTR/BLQ>s    Mean      SD     CV (%) Mean   Geometric Mean   CV % Geometric Mean   Median   Minimum   Maximum
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      A: Drug X                                                                                                                                               
+        Day 1                                                                                                                                                 
+          0                                                                                                                                                   
+            0                             402      402         0        0          NE              NE                 NE              0         0         0   
+          0.5                                                                                                                                                 
+            0.5                           134       0         12.6     1.51       12.0            12.5               12.2            12.6     9.72      15.6  
+          1                                                                                                                                                   
+            1                             134       0         16.2     1.63       10.0            16.1               10.1            16.2     12.6      19.9  
+          1.5                                                                                                                                                 
+            1.5                           134       0         15.6     1.46        9.3            15.6                9.3            15.5     12.3       19   
+          2                                                                                                                                                   
+            2                             134       0         13.4     1.35       10.1            13.4               10.0            13.3     10.8      16.5  
+          3                                                                                                                                                   
+            3                             134       0         8.47     1.25       14.7            8.38               15.0            8.4      5.88      10.9  
+          4                                                                                                                                                   
+            4                             402       0         4.79     1.01       21.2            4.69               21.9            4.79      2.7      7.09  
+          8                                                                                                                                                   
+            8                             402       0        0.348    0.179       51.6           0.303               58.2           0.318     0.076     0.866 
+          12                                                                                                                                                  
+            12                            402       0        0.0224   0.0189      84.4           0.0156              111.2          0.017     0.002     0.083 
+        Day 2                                                                                                                                                 
+          24                                                                                                                                                  
+            24                            402      402         0        0          NE              NE                 NE              0         0         0   
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      
+      NE: Not Estimable
+

--- a/package/tests/testthat/_snaps/pkpt02/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt02/markdown-snaps.md
@@ -1,0 +1,74 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Plasma PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug X 
+      Visit: CYCLE 1 DAY 1
+      
+      ——————————————————————————————————————————————————————————————————————
+      PK Parameter                     ARM A                   ARM C        
+      ——————————————————————————————————————————————————————————————————————
+      Cmax (ug/mL)                                                          
+        n                               134                     132         
+        Mean (SD)              3.025e+01 (6.239e+00)   3.004e+01 (5.457e+00)
+        CV (%)                         20.6                    18.2         
+        Geometric Mean               2.961e+01               2.954e+01      
+        CV % Geometric Mean            21.0                    18.9         
+        Median                       2.986e+01               2.977e+01      
+        Min - Max              1.753e+01 - 4.871e+01   1.585e+01 - 4.757e+01
+      AUCinf obs (day*ug/mL)                                                
+        n                               134                     132         
+        Mean (SD)              2.028e+02 (3.766e+01)   1.955e+02 (3.785e+01)
+        CV (%)                         18.6                    19.4         
+        Geometric Mean               1.994e+02               1.917e+02      
+        CV % Geometric Mean            18.7                    20.1         
+        Median                       1.971e+02               1.962e+02      
+        Min - Max              1.253e+02 - 3.110e+02   1.030e+02 - 3.145e+02
+      CL obs (ml/day/kg)                                                    
+        n                               134                     132         
+        Mean (SD)              5.043e+00 (1.041e+00)   5.009e+00 (9.846e-01)
+        CV (%)                         20.6                    19.7         
+        Geometric Mean               4.929e+00               4.907e+00      
+        CV % Geometric Mean            22.4                    21.1         
+        Median                       5.078e+00               4.969e+00      
+        Min - Max              2.255e+00 - 7.395e+00   2.102e+00 - 7.489e+00
+
+# result_v2
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Plasma PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug Y 
+      Visit: CYCLE 1 DAY 1
+      
+      ——————————————————————————————————————————————
+      PK Parameter                     ARM C        
+      ——————————————————————————————————————————————
+      Cmax (ug/mL)                                  
+        n                               132         
+        Mean (SD)              2.990e+01 (5.550e+00)
+        CV (%)                         18.6         
+        Geometric Mean               2.935e+01      
+        CV % Geometric Mean            20.1         
+        Median                       2.969e+01      
+        Min - Max              1.406e+01 - 4.345e+01
+      AUCinf obs (day*ug/mL)                        
+        n                               132         
+        Mean (SD)              1.986e+02 (3.792e+01)
+        CV (%)                         19.1         
+        Geometric Mean               1.952e+02      
+        CV % Geometric Mean            18.9         
+        Median                       1.953e+02      
+        Min - Max              1.264e+02 - 3.183e+02
+      CL obs (ml/day/kg)                            
+        n                               132         
+        Mean (SD)              4.955e+00 (8.951e-01)
+        CV (%)                         18.1         
+        Geometric Mean               4.873e+00      
+        CV % Geometric Mean            18.7         
+        Median                       4.936e+00      
+        Min - Max              2.987e+00 - 7.211e+00
+

--- a/package/tests/testthat/_snaps/pkpt03/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt03/markdown-snaps.md
@@ -1,0 +1,49 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Plasma PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug X 
+      Visit: CYCLE 1 DAY 1
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Treatment Arm                                                                                                                               
+        PK Parameter                n      Mean         SD       CV (%)   Geometric Mean   CV % Geometric Mean    Median      Minimum     Maximum 
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      ARM A                                                                                                                                       
+        Cmax (ug/mL)                                                                                                                              
+          Cmax (ug/mL)             134   3.025e+01   6.239e+00    20.6      2.961e+01             21.0           2.986e+01   1.753e+01   4.871e+01
+        AUCinf obs (day*ug/mL)                                                                                                                    
+          AUCinf obs (day*ug/mL)   134   2.028e+02   3.766e+01    18.6      1.994e+02             18.7           1.971e+02   1.253e+02   3.110e+02
+        CL obs (ml/day/kg)                                                                                                                        
+          CL obs (ml/day/kg)       134   5.043e+00   1.041e+00    20.6      4.929e+00             22.4           5.078e+00   2.255e+00   7.395e+00
+      ARM C                                                                                                                                       
+        Cmax (ug/mL)                                                                                                                              
+          Cmax (ug/mL)             132   3.004e+01   5.457e+00    18.2      2.954e+01             18.9           2.977e+01   1.585e+01   4.757e+01
+        AUCinf obs (day*ug/mL)                                                                                                                    
+          AUCinf obs (day*ug/mL)   132   1.955e+02   3.785e+01    19.4      1.917e+02             20.1           1.962e+02   1.030e+02   3.145e+02
+        CL obs (ml/day/kg)                                                                                                                        
+          CL obs (ml/day/kg)       132   5.009e+00   9.846e-01    19.7      4.907e+00             21.1           4.969e+00   2.102e+00   7.489e+00
+
+# result_v2
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Plasma PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug Y 
+      Visit: CYCLE 1 DAY 1
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Treatment Arm                                                                                                                               
+        PK Parameter                n      Mean         SD       CV (%)   Geometric Mean   CV % Geometric Mean    Median      Minimum     Maximum 
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      ARM C                                                                                                                                       
+        Cmax (ug/mL)                                                                                                                              
+          Cmax (ug/mL)             132   2.990e+01   5.550e+00    18.6      2.935e+01             20.1           2.969e+01   1.406e+01   4.345e+01
+        AUCinf obs (day*ug/mL)                                                                                                                    
+          AUCinf obs (day*ug/mL)   132   1.986e+02   3.792e+01    19.1      1.952e+02             18.9           1.953e+02   1.264e+02   3.183e+02
+        CL obs (ml/day/kg)                                                                                                                        
+          CL obs (ml/day/kg)       132   4.955e+00   8.951e-01    18.1      4.873e+00             18.7           4.936e+00   2.987e+00   7.211e+00
+

--- a/package/tests/testthat/_snaps/pkpt04/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt04/markdown-snaps.md
@@ -1,0 +1,90 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Urine PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug X 
+      Visit: CYCLE 1 DAY 1
+      
+      —————————————————————————————————————————————————————————————————————
+      PK Parameter                    ARM A                   ARM C        
+      —————————————————————————————————————————————————————————————————————
+      Ae (mg)                                                              
+        n                              268                     264         
+        Mean (SD)             1.551e+00 (3.385e-01)   1.535e+00 (2.978e-01)
+        CV (%)                        21.8                    19.4         
+        Geometric Mean              1.513e+00               1.505e+00      
+        CV % Geometric Mean           23.0                    20.3         
+        Median                      1.547e+00               1.547e+00      
+        Min - Max             7.021e-01 - 2.464e+00   8.502e-01 - 2.208e+00
+      Fe (%)                                                               
+        n                              268                     264         
+        Mean (SD)             1.571e+01 (3.348e+00)   1.609e+01 (3.103e+00)
+        CV (%)                        21.3                    19.3         
+        Geometric Mean              1.534e+01               1.578e+01      
+        CV % Geometric Mean           22.2                    20.2         
+        Median                      1.577e+01               1.604e+01      
+        Min - Max             8.147e+00 - 2.452e+01   8.503e+00 - 2.443e+01
+      CLR (L/hr)                                                           
+        n                              134                     132         
+        Mean (SD)             4.918e-02 (9.611e-03)   5.024e-02 (1.050e-02)
+        CV (%)                        19.5                    20.9         
+        Geometric Mean              4.818e-02               4.913e-02      
+        CV % Geometric Mean           21.0                    21.9         
+        Median                      4.909e-02               4.984e-02      
+        Min - Max             2.488e-02 - 7.511e-02   2.505e-02 - 8.560e-02
+      RENALCLD (L/hr/mg)                                                   
+        n                              134                     132         
+        Mean (SD)             4.873e-03 (9.654e-04)   5.110e-03 (9.339e-04)
+        CV (%)                        19.8                    18.3         
+        Geometric Mean              4.772e-03               5.019e-03      
+        CV % Geometric Mean           21.2                    19.7         
+        Median                      4.967e-03               5.151e-03      
+        Min - Max             2.385e-03 - 7.258e-03   2.356e-03 - 7.407e-03
+
+# result_v2
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Urine PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug Y 
+      Visit: CYCLE 1 DAY 1
+      
+      —————————————————————————————————————————————
+      PK Parameter                    ARM C        
+      —————————————————————————————————————————————
+      Ae (mg)                                      
+        n                              264         
+        Mean (SD)             1.598e+00 (3.154e-01)
+        CV (%)                        19.7         
+        Geometric Mean              1.565e+00      
+        CV % Geometric Mean           21.4         
+        Median                      1.603e+00      
+        Min - Max             8.574e-01 - 2.257e+00
+      Fe (%)                                       
+        n                              264         
+        Mean (SD)             1.583e+01 (3.077e+00)
+        CV (%)                        19.4         
+        Geometric Mean              1.552e+01      
+        CV % Geometric Mean           20.2         
+        Median                      1.570e+01      
+        Min - Max             8.311e+00 - 2.378e+01
+      CLR (L/hr)                                   
+        n                              132         
+        Mean (SD)             4.966e-02 (1.009e-02)
+        CV (%)                        20.3         
+        Geometric Mean              4.857e-02      
+        CV % Geometric Mean           22.0         
+        Median                      4.912e-02      
+        Min - Max             1.839e-02 - 7.761e-02
+      RENALCLD (L/hr/mg)                           
+        n                              132         
+        Mean (SD)             5.093e-03 (1.032e-03)
+        CV (%)                        20.3         
+        Geometric Mean              4.985e-03      
+        CV % Geometric Mean           21.4         
+        Median                      5.017e-03      
+        Min - Max             2.356e-03 - 7.939e-03
+

--- a/package/tests/testthat/_snaps/pkpt05/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt05/markdown-snaps.md
@@ -1,0 +1,55 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Urine PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug X 
+      Visit: CYCLE 1 DAY 1
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Treatment Arm                                                                                                                           
+        PK Parameter            n      Mean         SD       CV (%)   Geometric Mean   CV % Geometric Mean    Median      Minimum     Maximum 
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      ARM A                                                                                                                                   
+        Ae (mg)                                                                                                                               
+          Ae (mg)              268   1.551e+00   3.385e-01    21.8      1.513e+00             23.0           1.547e+00   7.021e-01   2.464e+00
+        Fe (%)                                                                                                                                
+          Fe (%)               268   1.571e+01   3.348e+00    21.3      1.534e+01             22.2           1.577e+01   8.147e+00   2.452e+01
+        CLR (L/hr)                                                                                                                            
+          CLR (L/hr)           134   4.918e-02   9.611e-03    19.5      4.818e-02             21.0           4.909e-02   2.488e-02   7.511e-02
+        RENALCLD (L/hr/mg)                                                                                                                    
+          RENALCLD (L/hr/mg)   134   4.873e-03   9.654e-04    19.8      4.772e-03             21.2           4.967e-03   2.385e-03   7.258e-03
+      ARM C                                                                                                                                   
+        Ae (mg)                                                                                                                               
+          Ae (mg)              264   1.535e+00   2.978e-01    19.4      1.505e+00             20.3           1.547e+00   8.502e-01   2.208e+00
+        Fe (%)                                                                                                                                
+          Fe (%)               264   1.609e+01   3.103e+00    19.3      1.578e+01             20.2           1.604e+01   8.503e+00   2.443e+01
+        CLR (L/hr)                                                                                                                            
+          CLR (L/hr)           132   5.024e-02   1.050e-02    20.9      4.913e-02             21.9           4.984e-02   2.505e-02   8.560e-02
+        RENALCLD (L/hr/mg)                                                                                                                    
+          RENALCLD (L/hr/mg)   132   5.110e-03   9.339e-04    18.3      5.019e-03             19.7           5.151e-03   2.356e-03   7.407e-03
+
+# result_v2
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Urine PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug Y 
+      Visit: CYCLE 1 DAY 1
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Treatment Arm                                                                                                                           
+        PK Parameter            n      Mean         SD       CV (%)   Geometric Mean   CV % Geometric Mean    Median      Minimum     Maximum 
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      ARM C                                                                                                                                   
+        Ae (mg)                                                                                                                               
+          Ae (mg)              264   1.598e+00   3.154e-01    19.7      1.565e+00             21.4           1.603e+00   8.574e-01   2.257e+00
+        Fe (%)                                                                                                                                
+          Fe (%)               264   1.583e+01   3.077e+00    19.4      1.552e+01             20.2           1.570e+01   8.311e+00   2.378e+01
+        CLR (L/hr)                                                                                                                            
+          CLR (L/hr)           132   4.966e-02   1.009e-02    20.3      4.857e-02             22.0           4.912e-02   1.839e-02   7.761e-02
+        RENALCLD (L/hr/mg)                                                                                                                    
+          RENALCLD (L/hr/mg)   132   5.093e-03   1.032e-03    20.3      4.985e-03             21.4           5.017e-03   2.356e-03   7.939e-03
+

--- a/package/tests/testthat/_snaps/pkpt06/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt06/markdown-snaps.md
@@ -1,0 +1,42 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Dose-Normalized PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug X 
+      Visit: CYCLE 1 DAY 1
+      
+      —————————————————————————————————————————————————————————————————————
+      PK Parameter                    ARM A                   ARM C        
+      —————————————————————————————————————————————————————————————————————
+      RENALCLD (L/hr/mg)                                                   
+        n                              134                     132         
+        Mean (SD)             4.873e-03 (9.654e-04)   5.110e-03 (9.339e-04)
+        CV (%)                        19.8                    18.3         
+        Geometric Mean              4.772e-03               5.019e-03      
+        CV % Geometric Mean           21.2                    19.7         
+        Median                      4.967e-03               5.151e-03      
+        Min - Max             2.385e-03 - 7.258e-03   2.356e-03 - 7.407e-03
+
+# result_v2
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Dose-Normalized PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug Y 
+      Visit: CYCLE 1 DAY 1
+      
+      —————————————————————————————————————————————
+      PK Parameter                    ARM C        
+      —————————————————————————————————————————————
+      RENALCLD (L/hr/mg)                           
+        n                              132         
+        Mean (SD)             5.093e-03 (1.032e-03)
+        CV (%)                        20.3         
+        Geometric Mean              4.985e-03      
+        CV % Geometric Mean           21.4         
+        Median                      5.017e-03      
+        Min - Max             2.356e-03 - 7.939e-03
+

--- a/package/tests/testthat/_snaps/pkpt07/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt07/markdown-snaps.md
@@ -1,0 +1,37 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Urine PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug X 
+      Visit: CYCLE 1 DAY 1
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Treatment Arm                                                                                                                           
+        PK Parameter            n      Mean         SD       CV (%)   Geometric Mean   CV % Geometric Mean    Median      Minimum     Maximum 
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      ARM A                                                                                                                                   
+        RENALCLD (L/hr/mg)                                                                                                                    
+          RENALCLD (L/hr/mg)   134   4.873e-03   9.654e-04    19.8      4.772e-03             21.2           4.967e-03   2.385e-03   7.258e-03
+      ARM C                                                                                                                                   
+        RENALCLD (L/hr/mg)                                                                                                                    
+          RENALCLD (L/hr/mg)   132   5.110e-03   9.339e-04    18.3      5.019e-03             19.7           5.151e-03   2.356e-03   7.407e-03
+
+# result_v2
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Urine PK Parameter by Treatment Arm, PK Population
+      Analyte: Plasma Drug Y 
+      Visit: CYCLE 1 DAY 1
+      
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      Treatment Arm                                                                                                                           
+        PK Parameter            n      Mean         SD       CV (%)   Geometric Mean   CV % Geometric Mean    Median      Minimum     Maximum 
+      ————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+      ARM C                                                                                                                                   
+        RENALCLD (L/hr/mg)                                                                                                                    
+          RENALCLD (L/hr/mg)   132   5.093e-03   1.032e-03    20.3      4.985e-03             21.4           5.017e-03   2.356e-03   7.939e-03
+

--- a/package/tests/testthat/_snaps/pkpt08/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt08/markdown-snaps.md
@@ -1,0 +1,32 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Summary of Cumulative Amount and Percentage of Urine Recovered from
+       Plasma Drug X following BID Administration for 0-24 hours, PK Population
+      Analyte: Plasma Drug X 
+      Visit: CYCLE 1 DAY 1
+      
+      —————————————————————————————————————————————————————————————
+      Treatment Arm           Accumulation Interval (hours)        
+                              0-12                    0-24         
+                       Ae (mg)     Fe (%)      Ae (mg)     Fe (%)  
+      —————————————————————————————————————————————————————————————
+      ARM A                                                        
+        n                134         134         134         134   
+        Mean          1.551e+00   1.571e+01   1.551e+00   1.571e+01
+        SD            3.391e-01   3.354e+00   3.391e-01   3.354e+00
+        CV (%)          21.9        21.4        21.9        21.4   
+        Median        1.547e+00   1.577e+01   1.547e+00   1.577e+01
+        Minimum       7.021e-01   8.147e+00   7.021e-01   8.147e+00
+        Maximum       2.464e+00   2.452e+01   2.464e+00   2.452e+01
+      ARM C                                                        
+        n                132         132         132         132   
+        Mean          1.535e+00   1.609e+01   1.535e+00   1.609e+01
+        SD            2.983e-01   3.109e+00   2.983e-01   3.109e+00
+        CV (%)          19.4        19.3        19.4        19.3   
+        Median        1.547e+00   1.604e+01   1.547e+00   1.604e+01
+        Minimum       8.502e-01   8.503e+00   8.502e-01   8.503e+00
+        Maximum       2.208e+00   2.443e+01   2.208e+00   2.443e+01
+

--- a/package/tests/testthat/_snaps/pkpt11/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpt11/markdown-snaps.md
@@ -1,0 +1,18 @@
+# result_v1
+
+    Code
+      print(data_snap[[i]])
+    Output
+      Estimated Ratios of Geometric Means and 90% Confidence Intervals for AUC and CMAX Following BID
+      of A: Drug X in Comparison with C: Combination, PK Population
+      Analyte: Plasma Drug X
+      
+      —————————————————————————————————————————————————————————————————————————————————————————————————
+      PK Parameter                                                                                     
+        Comparison                  n    Geometric Mean Ratio   90% CI Lower Bound   90% CI Upper Bound
+      —————————————————————————————————————————————————————————————————————————————————————————————————
+      AUCinf obs (day*ug/mL)                                                                           
+        C: Combination/A: Drug X   266        9.615e-01             9.247e-01            9.998e-01     
+      Cmax (ug/mL)                                                                                     
+        C: Combination/A: Drug X   266        9.974e-01             9.583e-01            1.038e+00     
+


### PR DESCRIPTION
Partially addresses #74 

### Scope of the PR

* Adds markdown snapshots for all the `tables/pharmacokinetic` articles