### PR TITLE
#74 (PR 8/12) - Adding snapshots for listings/other

### DIFF
--- a/book/listings/other/ael01.qmd
+++ b/book/listings/other/ael01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Preferred Terms, Lowest Level Terms, and Investigator-Speci
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -31,7 +33,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("AESOC", "AEDECOD", "AELLT"),
@@ -41,6 +43,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/ael01_nollt.qmd
+++ b/book/listings/other/ael01_nollt.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Preferred Terms and Investigator-Specified Adverse Event Te
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -30,7 +32,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("AESOC", "AEDECOD"),
@@ -40,6 +42,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/ael02.qmd
+++ b/book/listings/other/ael02.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Adverse Events
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -65,7 +67,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("CPID", "ASR", "TRT01A"),
@@ -81,6 +83,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/ael02_ed.qmd
+++ b/book/listings/other/ael02_ed.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Adverse Events (for Early Development Studies)
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -83,7 +85,7 @@ out <- out %>% var_relabel(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("cent_subj", "ASR", "TRT01A"),
@@ -99,6 +101,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/ael03.qmd
+++ b/book/listings/other/ael03.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Serious Adverse Events
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -74,7 +76,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("CPID", "ASR", "TRT01A"),
@@ -94,6 +96,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/ael04.qmd
+++ b/book/listings/other/ael04.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Patient Deaths
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -41,7 +43,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = "ID",
@@ -51,6 +53,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/cml01.qmd
+++ b/book/listings/other/cml01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Previous and Concomitant Medications
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -52,7 +54,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("ID", "AGSXRC", "TRT01A", "CMDECOD"),
@@ -62,6 +64,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/cml02a_gl.qmd
+++ b/book/listings/other/cml02a_gl.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Concomitant Medication Class Level 2, Preferred Name, and I
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -30,7 +32,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("ATC2", "CMDECOD", "CMTRT"),
@@ -40,6 +42,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/cml02b_gl.qmd
+++ b/book/listings/other/cml02b_gl.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Concomitant Medication Class, Preferred Name, and Investiga
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -33,7 +35,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("ATC1", "ATC2", "ATC3", "ATC4", "CMDECOD", "CMTRT"),
@@ -43,6 +45,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/dsl01.qmd
+++ b/book/listings/other/dsl01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Patients with Study Drug Withdrawn Due to Adverse Events
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -40,7 +42,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   disp_cols = names(out),
@@ -49,6 +51,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/dsl02.qmd
+++ b/book/listings/other/dsl02.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Patients Who Discontinued Early from Study
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -48,7 +50,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   disp_cols = names(out),
@@ -57,6 +59,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/dsur4.qmd
+++ b/book/listings/other/dsur4.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Patients Who Died During Reporting Period
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -31,7 +33,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("ARM"),
@@ -42,6 +44,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/egl01.qmd
+++ b/book/listings/other/egl01.qmd
@@ -5,6 +5,8 @@ subtitle: 'Listing of ECG Data: Safety-Evaluable Patients'
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -68,7 +70,7 @@ out <- anl_eg %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("CRTNPT", "AGSXRC", "TRT01A", "AVISIT", "ADY"),
@@ -80,6 +82,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/exl01.qmd
+++ b/book/listings/other/exl01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Exposure to Study Drug
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -40,7 +42,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("CRTNPT", "AVISIT"),
@@ -50,6 +52,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/lbl01.qmd
+++ b/book/listings/other/lbl01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Laboratory Test Results
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -64,7 +66,7 @@ out <- out %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("CPID", "TRT01A"),
@@ -75,6 +77,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/lbl01_rls.qmd
+++ b/book/listings/other/lbl01_rls.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Laboratory Test Results Using Roche Safety Lab Standardizat
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -69,7 +71,7 @@ out <- out %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("CPID", "TRT01A"),
@@ -81,6 +83,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/lbl02a.qmd
+++ b/book/listings/other/lbl02a.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Laboratory Abnormalities (constant units)
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -64,7 +66,7 @@ out <- out %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("LBTEST_U", "TRT01A", "CPID"),
@@ -75,6 +77,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/lbl02a_rls.qmd
+++ b/book/listings/other/lbl02a_rls.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Laboratory Abnormalities Defined by Roche Safety Lab Standa
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -84,7 +86,7 @@ out <- out %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("LBTEST_U", "TRT01A", "CPID"),
@@ -97,6 +99,8 @@ or low low (LL) if outside the marked reference range with a clinically relevant
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/lbl02b.qmd
+++ b/book/listings/other/lbl02b.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Laboratory Abnormalities (variable units)
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -65,7 +67,7 @@ out <- out %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("LBTEST", "TRT01A", "CPID"),
@@ -76,6 +78,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/mhl01.qmd
+++ b/book/listings/other/mhl01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Medical History and Concurrent Diseases
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -44,7 +46,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("ID", "ASR", "TRT01A", "MHBODSYS", "MHDECOD"),
@@ -54,6 +56,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/oncl01.qmd
+++ b/book/listings/other/oncl01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Individual Efficacy Data
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -84,7 +86,7 @@ out <- out %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("ID", "TRT01A"),
@@ -95,6 +97,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/other/vsl01.qmd
+++ b/book/listings/other/vsl01.qmd
@@ -5,6 +5,8 @@ subtitle: 'Listing of Vital Signs: Safety-Evaluable Patients'
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -77,7 +79,7 @@ out <- anl_vs %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("CRTNPT", "AGSXRC", "TRT01A", "AVISIT"),
@@ -89,6 +91,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/package/tests/testthat/_snaps/ael01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/ael01/markdown-snaps.md
@@ -1,0 +1,19 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 10 x 4
+         AESOC      AEDECOD       AELLT         AETERM       
+         <lstng_ky> <lstng_ky>    <lstng_ky>    <fct>        
+       1 cl A       dcd A.1.1.1.1 llt A.1.1.1.1 trm A.1.1.1.1
+       2 cl A       dcd A.1.1.1.2 llt A.1.1.1.2 trm A.1.1.1.2
+       3 cl B       dcd B.1.1.1.1 llt B.1.1.1.1 trm B.1.1.1.1
+       4 cl B       dcd B.2.1.2.1 llt B.2.1.2.1 trm B.2.1.2.1
+       5 cl B       dcd B.2.2.3.1 llt B.2.2.3.1 trm B.2.2.3.1
+       6 cl C       dcd C.1.1.1.3 llt C.1.1.1.3 trm C.1.1.1.3
+       7 cl C       dcd C.2.1.2.1 llt C.2.1.2.1 trm C.2.1.2.1
+       8 cl D       dcd D.1.1.1.1 llt D.1.1.1.1 trm D.1.1.1.1
+       9 cl D       dcd D.1.1.4.2 llt D.1.1.4.2 trm D.1.1.4.2
+      10 cl D       dcd D.2.1.5.3 llt D.2.1.5.3 trm D.2.1.5.3
+

--- a/package/tests/testthat/_snaps/ael01_nollt/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/ael01_nollt/markdown-snaps.md
@@ -1,0 +1,19 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 10 x 3
+         AESOC      AEDECOD       AETERM       
+         <lstng_ky> <lstng_ky>    <fct>        
+       1 cl A       dcd A.1.1.1.1 trm A.1.1.1.1
+       2 cl A       dcd A.1.1.1.2 trm A.1.1.1.2
+       3 cl B       dcd B.1.1.1.1 trm B.1.1.1.1
+       4 cl B       dcd B.2.1.2.1 trm B.2.1.2.1
+       5 cl B       dcd B.2.2.3.1 trm B.2.2.3.1
+       6 cl C       dcd C.1.1.1.3 trm C.1.1.1.3
+       7 cl C       dcd C.2.1.2.1 trm C.2.1.2.1
+       8 cl D       dcd D.1.1.1.1 trm D.1.1.1.1
+       9 cl D       dcd D.1.1.4.2 trm D.1.1.4.2
+      10 cl D       dcd D.2.1.5.3 trm D.2.1.5.3
+

--- a/package/tests/testthat/_snaps/ael02/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/ael02/markdown-snaps.md
@@ -1,0 +1,21 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 1,934 x 13
+         CPID     ASR   TRT01A AEDECOD Date_First ASTDY Duration Serious AESEV Related
+         <lstng_> <lst> <lstn> <fct>   <chr>      <int>    <dbl> <chr>   <fct> <chr>  
+       1 BRA-1/i~ 47/M~ A: Dr~ dcd B.~ 04NOV2020    162      173 No      MODE~ No     
+       2 BRA-1/i~ 47/M~ A: Dr~ dcd D.~ 04NOV2020    196      166 No      MODE~ No     
+       3 BRA-1/i~ 47/M~ A: Dr~ dcd A.~ 04NOV2020    321      149 Yes     MODE~ No     
+       4 BRA-1/i~ 47/M~ A: Dr~ dcd A.~ 04NOV2020    393       43 Yes     MODE~ No     
+       5 BRA-1/i~ 35/F~ C: Co~ dcd B.~ 25JUL2020    387       11 No      MODE~ No     
+       6 BRA-1/i~ 35/F~ C: Co~ dcd D.~ 25JUL2020    455      628 No      MILD  Yes    
+       7 BRA-1/i~ 35/F~ C: Co~ dcd A.~ 25JUL2020    739       36 No      MILD  No     
+       8 BRA-1/i~ 35/F~ C: Co~ dcd A.~ 25JUL2020    899      139 Yes     MODE~ No     
+       9 BRA-1/i~ 35/F~ C: Co~ dcd A.~ 25JUL2020    951       66 No      MILD  No     
+      10 BRA-1/i~ 35/F~ C: Co~ dcd D.~ 25JUL2020   1093        3 Yes     SEVE~ Yes    
+      # i 1,924 more rows
+      # i 3 more variables: Outcome <dbl>, Treated <chr>, Action <dbl>
+

--- a/package/tests/testthat/_snaps/ael02_ed/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/ael02_ed/markdown-snaps.md
@@ -1,0 +1,22 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 1,934 x 15
+         cent_subj    ASR   TRT01A AEDECOD ASTDY  TMOD  TMOH  TMOM ADURN AESER_F AESEV
+         <lstng_ky>   <lst> <lstn> <fct>   <int> <dbl> <dbl> <dbl> <dbl> <chr>   <fct>
+       1 BRA-1/id-134 47/M~ A: Dr~ dcd B.~   162     7    19     4   173 No      MODE~
+       2 BRA-1/id-134 47/M~ A: Dr~ dcd D.~   196     1    20    48   166 No      MODE~
+       3 BRA-1/id-134 47/M~ A: Dr~ dcd A.~   321    28    12    54   149 Yes     MODE~
+       4 BRA-1/id-134 47/M~ A: Dr~ dcd A.~   393    12    19    17    43 Yes     MODE~
+       5 BRA-1/id-141 35/F~ C: Co~ dcd B.~   387    25     8    22    11 No      MODE~
+       6 BRA-1/id-141 35/F~ C: Co~ dcd D.~   455     6    16    56   628 No      MILD 
+       7 BRA-1/id-141 35/F~ C: Co~ dcd A.~   739     0     9    38    36 No      MILD 
+       8 BRA-1/id-141 35/F~ C: Co~ dcd A.~   899    -1    23     6   139 Yes     MODE~
+       9 BRA-1/id-141 35/F~ C: Co~ dcd A.~   951     6    22    41    66 No      MILD 
+      10 BRA-1/id-141 35/F~ C: Co~ dcd D.~  1093    21     5    35     3 Yes     SEVE~
+      # i 1,924 more rows
+      # i 4 more variables: AEREL_F <chr>, AEOUT_F <dbl>, AECONTRT_F <chr>,
+      #   AEACN_F <dbl>
+

--- a/package/tests/testthat/_snaps/ael03/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/ael03/markdown-snaps.md
@@ -1,0 +1,21 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 786 x 13
+         CPID     ASR   TRT01A AEDECOD Date_First ASTDY Duration AESEV Related Outcome
+         <lstng_> <lst> <lstn> <fct>   <chr>      <int>    <dbl> <fct> <chr>     <dbl>
+       1 BRA-1/i~ 47/M~ A: Dr~ dcd A.~ 04NOV2020    321      149 MODE~ No            5
+       2 BRA-1/i~ 47/M~ A: Dr~ dcd A.~ 04NOV2020    393       43 MODE~ No            5
+       3 BRA-1/i~ 35/F~ C: Co~ dcd A.~ 25JUL2020    899      139 MODE~ No            4
+       4 BRA-1/i~ 35/F~ C: Co~ dcd D.~ 25JUL2020   1093        3 SEVE~ Yes           1
+       5 BRA-1/i~ 32/M~ B: Pl~ dcd B.~ 15JAN2021     33      614 SEVE~ Yes           1
+       6 BRA-1/i~ 32/M~ B: Pl~ dcd B.~ 15JAN2021    271      775 SEVE~ Yes           1
+       7 BRA-1/i~ 32/M~ B: Pl~ dcd B.~ 15JAN2021   1051        7 SEVE~ Yes           1
+       8 BRA-1/i~ 25/M~ C: Co~ dcd D.~ 07OCT2019    685       37 SEVE~ Yes           1
+       9 BRA-1/i~ 36/M~ A: Dr~ dcd D.~ 01JAN2020     64      630 SEVE~ Yes           1
+      10 BRA-1/i~ 36/M~ A: Dr~ dcd A.~ 01JAN2020    160      259 MODE~ No            2
+      # i 776 more rows
+      # i 3 more variables: Treated <chr>, Action <dbl>, SERREAS <chr>
+

--- a/package/tests/testthat/_snaps/ael04/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/ael04/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 70 x 8
+         ID            AGSXRC     TRT01A         TRTSD    EOSDY DTHADY DTHCAUS ADTHAUT
+         <lstng_ky>    <chr>      <fct>          <chr>    <int>  <int> <fct>   <fct>  
+       1 BRA-1/id-134  47/M/WHITE A: Drug X      04NOV20~   473    496 ADVERS~ Yes    
+       2 BRA-1/id-265  25/M/WHITE C: Combination 07OCT20~   863    872 SUICIDE No     
+       3 BRA-1/id-93   34/F/ASIAN A: Drug X      20JUN20~   610    657 ADVERS~ Yes    
+       4 BRA-11/id-217 43/M/ASIAN A: Drug X      28SEP20~   871    893 ADVERS~ Yes    
+       5 BRA-11/id-9   40/M/ASIAN C: Combination 25MAR20~  1056   1091 DISEAS~ Yes    
+       6 BRA-14/id-120 33/F/ASIAN C: Combination 19SEP20~   512    546 ADVERS~ Yes    
+       7 BRA-15/id-36  38/F/ASIAN A: Drug X      08JAN20~   767    812 DISEAS~ Yes    
+       8 CAN-1/id-341  43/F/ASIAN B: Placebo     23MAY20~   998   1013 SUICIDE Yes    
+       9 CAN-11/id-139 31/M/ASIAN A: Drug X      15SEP20~   519    563 ADVERS~ Yes    
+      10 CHN-1/id-123  27/F/ASIAN A: Drug X      28JAN20~   750    750 DISEAS~ Yes    
+      # i 60 more rows
+

--- a/package/tests/testthat/_snaps/cml01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/cml01/markdown-snaps.md
@@ -1,0 +1,21 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 3,685 x 14
+         ID      AGSXRC TRT01A CMDECOD TRTSD CMASTD ASTDY ADURN CMSTRFL CMENRFL CMDOSE
+         <lstng> <lstn> <lstn> <lstng> <chr> <chr>  <int> <int> <chr>   <chr>    <int>
+       1 BRA-1/~ 47/M/~ A: Dr~ mednam~ 04NO~ 21SEP~   321  -148 No      No          30
+       2 BRA-1/~ 47/M/~ A: Dr~ mednam~ 04NO~ 02DEC~   393   -42 No      No          41
+       3 BRA-1/~ 47/M/~ A: Dr~ mednam~ 04NO~ 15APR~   162  -172 No      No          25
+       4 BRA-1/~ 47/M/~ A: Dr~ mednam~ 04NO~ 15APR~   162  -172 No      No          25
+       5 BRA-1/~ 47/M/~ A: Dr~ mednam~ 04NO~ 15APR~   162  -172 No      No          25
+       6 BRA-1/~ 47/M/~ A: Dr~ mednam~ 04NO~ 19MAY~   196  -165 No      No          22
+       7 BRA-1/~ 47/M/~ A: Dr~ mednam~ 04NO~ 19MAY~   196  -165 No      No          22
+       8 BRA-1/~ 35/F/~ C: Co~ mednam~ 25JU~ 03AUG~   739   -35 No      No          84
+       9 BRA-1/~ 35/F/~ C: Co~ mednam~ 25JU~ 10JAN~   899  -138 No      No           1
+      10 BRA-1/~ 35/F/~ C: Co~ mednam~ 25JU~ 03MAR~   951   -65 No      No          70
+      # i 3,675 more rows
+      # i 3 more variables: CMDOSU <fct>, CMDOSFRQ <fct>, CMROUTE <fct>
+

--- a/package/tests/testthat/_snaps/cml02a_gl/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/cml02a_gl/markdown-snaps.md
@@ -1,0 +1,26 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 17 x 3
+         ATC2          CMDECOD       CMTRT     
+         <lstng_ky>    <lstng_ky>    <lstng_ky>
+       1 ATCCLAS2 A    medname A_1/3 A_1/3     
+       2 ATCCLAS2 A    medname A_2/3 A_2/3     
+       3 ATCCLAS2 A    medname A_3/3 A_3/3     
+       4 ATCCLAS2 A p2 medname A_3/3 A_3/3     
+       5 ATCCLAS2 B    medname B_1/4 B_1/4     
+       6 ATCCLAS2 B    medname B_2/4 B_2/4     
+       7 ATCCLAS2 B    medname B_3/4 B_3/4     
+       8 ATCCLAS2 B    medname B_4/4 B_4/4     
+       9 ATCCLAS2 B p2 medname B_1/4 B_1/4     
+      10 ATCCLAS2 B p2 medname B_2/4 B_2/4     
+      11 ATCCLAS2 B p3 medname B_1/4 B_1/4     
+      12 ATCCLAS2 B p3 medname B_2/4 B_2/4     
+      13 ATCCLAS2 C    medname C_1/2 C_1/2     
+      14 ATCCLAS2 C    medname C_2/2 C_2/2     
+      15 ATCCLAS2 C p2 medname C_1/2 C_1/2     
+      16 ATCCLAS2 C p2 medname C_2/2 C_2/2     
+      17 ATCCLAS2 C p3 medname C_2/2 C_2/2     
+

--- a/package/tests/testthat/_snaps/cml02b_gl/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/cml02b_gl/markdown-snaps.md
@@ -1,0 +1,26 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 17 x 6
+         ATC1          ATC2          ATC3          ATC4          CMDECOD       CMTRT  
+         <lstng_ky>    <lstng_ky>    <lstng_ky>    <lstng_ky>    <lstng_ky>    <lstng>
+       1 ATCCLAS1 A    ATCCLAS2 A    ATCCLAS3 A    ATCCLAS4 A    medname A_1/3 A_1/3  
+       2 ATCCLAS1 A    ATCCLAS2 A    ATCCLAS3 A    ATCCLAS4 A    medname A_2/3 A_2/3  
+       3 ATCCLAS1 A    ATCCLAS2 A    ATCCLAS3 A    ATCCLAS4 A    medname A_3/3 A_3/3  
+       4 ATCCLAS1 A p2 ATCCLAS2 A p2 ATCCLAS3 A p2 ATCCLAS4 A p2 medname A_3/3 A_3/3  
+       5 ATCCLAS1 B    ATCCLAS2 B    ATCCLAS3 B    ATCCLAS4 B    medname B_1/4 B_1/4  
+       6 ATCCLAS1 B    ATCCLAS2 B    ATCCLAS3 B    ATCCLAS4 B    medname B_2/4 B_2/4  
+       7 ATCCLAS1 B    ATCCLAS2 B    ATCCLAS3 B    ATCCLAS4 B    medname B_3/4 B_3/4  
+       8 ATCCLAS1 B    ATCCLAS2 B    ATCCLAS3 B    ATCCLAS4 B    medname B_4/4 B_4/4  
+       9 ATCCLAS1 B p2 ATCCLAS2 B p2 ATCCLAS3 B p2 ATCCLAS4 B p2 medname B_1/4 B_1/4  
+      10 ATCCLAS1 B p2 ATCCLAS2 B p2 ATCCLAS3 B p2 ATCCLAS4 B p2 medname B_2/4 B_2/4  
+      11 ATCCLAS1 B p3 ATCCLAS2 B p3 ATCCLAS3 B p3 ATCCLAS4 B p3 medname B_1/4 B_1/4  
+      12 ATCCLAS1 B p3 ATCCLAS2 B p3 ATCCLAS3 B p3 ATCCLAS4 B p3 medname B_2/4 B_2/4  
+      13 ATCCLAS1 C    ATCCLAS2 C    ATCCLAS3 C    ATCCLAS4 C    medname C_1/2 C_1/2  
+      14 ATCCLAS1 C    ATCCLAS2 C    ATCCLAS3 C    ATCCLAS4 C    medname C_2/2 C_2/2  
+      15 ATCCLAS1 C p2 ATCCLAS2 C p2 ATCCLAS3 C p2 ATCCLAS4 C p2 medname C_1/2 C_1/2  
+      16 ATCCLAS1 C p2 ATCCLAS2 C p2 ATCCLAS3 C p2 ATCCLAS4 C p2 medname C_2/2 C_2/2  
+      17 ATCCLAS1 C p3 ATCCLAS2 C p3 ATCCLAS3 C p3 ATCCLAS4 C p3 medname C_2/2 C_2/2  
+

--- a/package/tests/testthat/_snaps/dsl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/dsl01/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 23 x 6
+         ID            ASR                            TRT01A       SSADM STDWD DISCONT
+         <lstng_ky>    <chr>                          <fct>        <chr> <dbl> <chr>  
+       1 BRA-1/id-42   36/M/BLACK OR AFRICAN AMERICAN A: Drug X    01JA~    NA No     
+       2 BRA-11/id-237 64/F/ASIAN                     C: Combinat~ 10MA~  1096 No     
+       3 CHN-1/id-26   29/M/WHITE                     A: Drug X    16JU~  1096 No     
+       4 CHN-1/id-62   36/F/WHITE                     A: Drug X    22NO~   455 Yes    
+       5 CHN-11/id-256 23/M/ASIAN                     A: Drug X    17MA~  1096 No     
+       6 CHN-11/id-257 32/F/ASIAN                     C: Combinat~ 15NO~  1096 No     
+       7 CHN-11/id-263 34/F/ASIAN                     C: Combinat~ 03AP~  1096 No     
+       8 CHN-11/id-349 40/M/ASIAN                     C: Combinat~ 13NO~  1096 No     
+       9 CHN-11/id-91  44/M/BLACK OR AFRICAN AMERICAN C: Combinat~ 29MA~   625 Yes    
+      10 CHN-13/id-102 37/M/ASIAN                     B: Placebo   23MA~  1096 No     
+      # i 13 more rows
+

--- a/package/tests/testthat/_snaps/dsl02/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/dsl02/markdown-snaps.md
@@ -1,0 +1,14 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 5 x 8
+        ID            ASR      TRT01A SSADTM              EOSDY SSAEDY RANDEDY DCSREAS
+        <lstng_ky>    <chr>    <fct>  <dttm>              <int>  <dbl>   <dbl> <fct>  
+      1 CHN-1/id-62   36/F/WH~ A: Dr~ 2020-11-22 00:00:00   455    454     455 DEATH  
+      2 CHN-11/id-91  44/M/BL~ C: Co~ 2020-05-29 00:00:00   625    625     626 DEATH  
+      3 CHN-9/id-11   28/F/NA~ B: Pl~ 2021-01-27 00:00:00   388    387     388 DEATH  
+      4 USA-11/id-100 40/F/AS~ C: Co~ 2020-03-10 00:00:00   705    705     707 LACK O~
+      5 USA-11/id-136 38/F/AS~ C: Co~ 2019-10-02 00:00:00   865    864     868 DEATH  
+

--- a/package/tests/testthat/_snaps/dsur4/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/dsur4/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 70 x 3
+         ARM        ID            DTHCAUS            
+         <lstng_ky> <chr>         <fct>              
+       1 A: Drug X  CHN-3/id-128  ADVERSE EVENT      
+       2 A: Drug X  RUS-1/id-52   DISEASE PROGRESSION
+       3 A: Drug X  CHN-1/id-235  ADVERSE EVENT      
+       4 A: Drug X  CHN-5/id-108  MISSING            
+       5 A: Drug X  CHN-17/id-182 LOST TO FOLLOW UP  
+       6 A: Drug X  BRA-11/id-217 ADVERSE EVENT      
+       7 A: Drug X  CHN-15/id-14  DISEASE PROGRESSION
+       8 A: Drug X  CHN-2/id-274  SUICIDE            
+       9 A: Drug X  USA-11/id-339 UNKNOWN            
+      10 A: Drug X  BRA-15/id-36  DISEASE PROGRESSION
+      # i 60 more rows
+

--- a/package/tests/testthat/_snaps/egl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/egl01/markdown-snaps.md
@@ -1,0 +1,21 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 2,400 x 11
+         CRTNPT AGSXRC TRT01A AVISIT ADY   AVAL_ANRIND_HR CHG_HR AVAL_ANRIND_QT CHG_QT
+         <lstn> <lstn> <lstn> <lstn> <lst> <chr>          <chr>  <chr>          <chr> 
+       1 BRA-1~ 38/M/~ A: Dr~ BASEL~ 149   "  66.94"      "    ~ " 441.78"      "    ~
+       2 BRA-1~ 38/M/~ A: Dr~ WEEK ~ 314   "  63.18"      "   -~ " 365.68"      "  -7~
+       3 BRA-1~ 38/M/~ A: Dr~ WEEK ~ 398   "  57.57"      "   -~ " 355.48"      "  -8~
+       4 BRA-1~ 38/M/~ A: Dr~ WEEK ~ 470   "  73.36"      "    ~ " 352.45"      "  -8~
+       5 BRA-1~ 38/M/~ A: Dr~ WEEK ~ 528   "  53.72"      "  -1~ " 388.42"      "  -5~
+       6 BRA-1~ 38/M/~ A: Dr~ WEEK ~ 535   "  58.25"      "   -~ " 291.77"      " -15~
+       7 BRA-1~ 47/M/~ A: Dr~ BASEL~ 227   "  46.99"      "    ~ " 385.29"      "    ~
+       8 BRA-1~ 47/M/~ A: Dr~ WEEK ~ 255   "  48.38"      "    ~ " 453.74"      "   6~
+       9 BRA-1~ 47/M/~ A: Dr~ WEEK ~ 269   "  35.40/L"    "  -1~ " 413.54"      "   2~
+      10 BRA-1~ 47/M/~ A: Dr~ WEEK ~ 357   "  60.50"      "   1~ " 394.23"      "    ~
+      # i 2,390 more rows
+      # i 2 more variables: AVAL_ANRIND_RR <chr>, CHG_RR <chr>
+

--- a/package/tests/testthat/_snaps/exl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/exl01/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 2,800 x 9
+         CRTNPT       AVISIT        EXSTDY EXENDY TRT01A   AVAL AVALU EXDOSFRQ EXROUTE
+         <lstng_ky>   <lstng_ky>     <int>  <int> <fct>   <dbl> <fct> <chr>    <chr>  
+       1 BRA-1/id-105 SCREENING         -1     -1 A: Dru~   960 mg    ONCE     INTRAV~
+       2 BRA-1/id-105 BASELINE           1      1 A: Dru~   960 mg    ONCE     INTRAV~
+       3 BRA-1/id-105 WEEK 1 DAY 8       8      8 A: Dru~   720 mg    ONCE     SUBCUT~
+       4 BRA-1/id-105 WEEK 2 DAY 15     15     15 A: Dru~   480 mg    ONCE     INTRAV~
+       5 BRA-1/id-105 WEEK 3 DAY 22     22     22 A: Dru~   480 mg    ONCE     INTRAV~
+       6 BRA-1/id-105 WEEK 4 DAY 29     29     29 A: Dru~   720 mg    ONCE     INTRAV~
+       7 BRA-1/id-105 WEEK 5 DAY 36     36     36 A: Dru~   720 mg    ONCE     INTRAV~
+       8 BRA-1/id-134 SCREENING         -1     -1 A: Dru~   960 mg    ONCE     INTRAV~
+       9 BRA-1/id-134 BASELINE           1      1 A: Dru~   720 mg    ONCE     INTRAV~
+      10 BRA-1/id-134 WEEK 1 DAY 8       8      8 A: Dru~   720 mg    ONCE     INTRAV~
+      # i 2,790 more rows
+

--- a/package/tests/testthat/_snaps/lbl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/lbl01/markdown-snaps.md
@@ -1,0 +1,23 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 2,800 x 7
+         CPID         TRT01A   ADY   DLD ALT\n(U/L / NCI CTCA~1 CRP\n(mg/L / NCI CTC~2
+         <lstng_ky>   <lstn> <int> <int> <chr>                  <chr>                 
+       1 BRA-1/id-105 A: Dr~    80    NA " 4.30 / L4"           " 9.09"               
+       2 BRA-1/id-105 A: Dr~   149    69 "24.70"                " 9.15"               
+       3 BRA-1/id-105 A: Dr~   314   165 "24.87"                "10.89 / H2"          
+       4 BRA-1/id-105 A: Dr~   398    84 " 3.67 / L3"           " 8.14"               
+       5 BRA-1/id-105 A: Dr~   470    72 "18.55"                "10.59 / H3"          
+       6 BRA-1/id-105 A: Dr~   528    58 " 7.73"                "10.09 / H3"          
+       7 BRA-1/id-105 A: Dr~   535     7 "23.51"                " 9.20"               
+       8 BRA-1/id-134 A: Dr~   225    NA " 7.37"                "10.46 / H1"          
+       9 BRA-1/id-134 A: Dr~   227     2 "16.42"                " 7.43 / L1"          
+      10 BRA-1/id-134 A: Dr~   255    28 "11.16"                " 9.41"               
+      # i 2,790 more rows
+      # i abbreviated names: 1: `ALT\n(U/L / NCI CTCAE grade)`,
+      #   2: `CRP\n(mg/L / NCI CTCAE grade)`
+      # i 1 more variable: `IGA\n(g/L / NCI CTCAE grade)` <chr>
+

--- a/package/tests/testthat/_snaps/lbl01_rls/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/lbl01_rls/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 2,800 x 7
+         CPID         TRT01A       ADY   DLD `ALT\n(U/L)` `CRP\n(mg/L)` `IGA\n(g/L)`
+         <lstng_ky>   <lstng_ky> <int> <int> <chr>        <chr>         <chr>       
+       1 BRA-1/id-105 A: Drug X     80    NA " 4.30 / L"  " 9.09"       " 2.84"     
+       2 BRA-1/id-105 A: Drug X    149    69 "24.70"      " 9.15"       " 2.93"     
+       3 BRA-1/id-105 A: Drug X    314   165 "24.87"      "10.89 / H"   " 2.66"     
+       4 BRA-1/id-105 A: Drug X    398    84 " 3.67 / L"  " 8.14"       " 2.86"     
+       5 BRA-1/id-105 A: Drug X    470    72 "18.55"      "10.59 / H"   " 2.88"     
+       6 BRA-1/id-105 A: Drug X    528    58 " 7.73"      "10.09 / H"   " 2.93"     
+       7 BRA-1/id-105 A: Drug X    535     7 "23.51"      " 9.20"       " 2.88"     
+       8 BRA-1/id-134 A: Drug X    225    NA " 7.37"      "10.46 / H"   " 2.86"     
+       9 BRA-1/id-134 A: Drug X    227     2 "16.42"      " 7.43 / L"   " 2.76"     
+      10 BRA-1/id-134 A: Drug X    255    28 "11.16"      " 9.41"       " 2.75"     
+      # i 2,790 more rows
+

--- a/package/tests/testthat/_snaps/lbl02a/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/lbl02a/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 1,645 x 9
+         LBTEST_U                TRT01A CPID    ADY ADTM    DLD AVAL  LBNRNG ANRIND_GR
+         <lstng_ky>              <lstn> <lst> <int> <chr> <dbl> <chr> <chr>  <fct>    
+       1 Alanine Aminotransfera~ A: Dr~ BRA-~    80 27MA~     0 " 4.~ 7.0 -~ L4       
+       2 Alanine Aminotransfera~ A: Dr~ BRA-~   398 10AP~   318 " 3.~ 7.0 -~ L3       
+       3 Alanine Aminotransfera~ A: Dr~ BRA-~   207 13JA~     0 " 6.~ 7.0 -~ L1       
+       4 Alanine Aminotransfera~ A: Dr~ BRA-~   326 19MA~     0 " 1.~ 7.0 -~ L1       
+       5 Alanine Aminotransfera~ A: Dr~ BRA-~   594 22JU~     0 " 0.~ 7.0 -~ L1       
+       6 Alanine Aminotransfera~ A: Dr~ BRA-~   281 30OC~     0 " 2.~ 7.0 -~ L1       
+       7 Alanine Aminotransfera~ A: Dr~ BRA-~   734 26JA~   453 " 3.~ 7.0 -~ L1       
+       8 Alanine Aminotransfera~ A: Dr~ CAN-~   465 12AP~     0 " 1.~ 7.0 -~ L2       
+       9 Alanine Aminotransfera~ A: Dr~ CHN-~   127 13DE~     0 " 5.~ 7.0 -~ L2       
+      10 Alanine Aminotransfera~ A: Dr~ CHN-~   197 21FE~    70 " 1.~ 7.0 -~ L4       
+      # i 1,635 more rows
+

--- a/package/tests/testthat/_snaps/lbl02a_rls/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/lbl02a_rls/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 8,400 x 11
+         LBTEST_U     TRT01A CPID    ADY   DLD AVAL  PCHG  STD_RNG LBNRNG CRC   ANRIND
+         <lstng_ky>   <lstn> <lst> <int> <dbl> <chr> <chr> <chr>   <chr>  <chr> <fct> 
+       1 Alanine Ami~ A: Dr~ BRA-~    80     0 " 4.~ "   ~ 5.5 - ~ 7 - 55 40% ~ "LL"  
+       2 Alanine Ami~ A: Dr~ BRA-~   149    69 "24.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+       3 Alanine Ami~ A: Dr~ BRA-~   314   165 "24.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+       4 Alanine Ami~ A: Dr~ BRA-~   398    84 " 3.~ "   ~ 5.5 - ~ 7 - 55 40% ~ "LL"  
+       5 Alanine Ami~ A: Dr~ BRA-~   470    72 "18.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+       6 Alanine Ami~ A: Dr~ BRA-~   528    58 " 7.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+       7 Alanine Ami~ A: Dr~ BRA-~   535     7 "23.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+       8 Alanine Ami~ A: Dr~ BRA-~   225     0 " 7.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+       9 Alanine Ami~ A: Dr~ BRA-~   227     2 "16.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+      10 Alanine Ami~ A: Dr~ BRA-~   255    28 "11.~ "   ~ 5.5 - ~ 7 - 55 40% ~ ""    
+      # i 8,390 more rows
+

--- a/package/tests/testthat/_snaps/lbl02b/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/lbl02b/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 1,112 x 10
+         LBTEST            TRT01A CPID    ADY ADTM    DLD AVAL  AVALU LBNRNG ANRIND_GR
+         <lstng_ky>        <lstn> <lst> <int> <chr> <dbl> <chr> <fct> <chr>  <fct>    
+       1 Alanine Aminotra~ A: Dr~ BRA-~    80 27MA~     0 " 4.~ U/L   7.0 -~ L4       
+       2 Alanine Aminotra~ A: Dr~ BRA-~   398 10AP~   318 " 3.~ U/L   7.0 -~ L3       
+       3 Alanine Aminotra~ A: Dr~ CAN-~   465 12AP~     0 " 1.~ U/L   7.0 -~ L2       
+       4 Alanine Aminotra~ A: Dr~ CHN-~   127 13DE~     0 " 5.~ U/L   7.0 -~ L2       
+       5 Alanine Aminotra~ A: Dr~ CHN-~   197 21FE~    70 " 1.~ U/L   7.0 -~ L4       
+       6 Alanine Aminotra~ A: Dr~ CHN-~   277 11OC~     0 " 5.~ U/L   7.0 -~ L4       
+       7 Alanine Aminotra~ A: Dr~ CHN-~   672 10NO~   395 " 6.~ U/L   7.0 -~ L2       
+       8 Alanine Aminotra~ A: Dr~ CHN-~   348 25JU~     0 " 3.~ U/L   7.0 -~ L3       
+       9 Alanine Aminotra~ A: Dr~ CHN-~   364 01JU~     0 " 5.~ U/L   7.0 -~ L2       
+      10 Alanine Aminotra~ A: Dr~ CHN-~   483 12MA~     0 " 1.~ U/L   7.0 -~ L4       
+      # i 1,102 more rows
+

--- a/package/tests/testthat/_snaps/mhl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/mhl01/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 1,934 x 11
+         ID     ASR   TRT01A MHBODSYS MHDECOD TRTSDTM ASTDTM ASTDY AENDTM AENDY ATIREL
+         <lstn> <lst> <lstn> <lstng_> <lstng> <chr>   <chr>  <int> <chr>  <int> <fct> 
+       1 BRA-1~ 47/M~ A: Dr~ cl A     trm A_~ 04NOV2~ 21SEP~   321 16FEB~   469 PRIOR~
+       2 BRA-1~ 47/M~ A: Dr~ cl A     trm A_~ 04NOV2~ 02DEC~   393 13JAN~   435 PRIOR~
+       3 BRA-1~ 47/M~ A: Dr~ cl B     trm B_~ 04NOV2~ 15APR~   162 04OCT~   334 PRIOR~
+       4 BRA-1~ 47/M~ A: Dr~ cl D     trm D_~ 04NOV2~ 19MAY~   196 31OCT~   361 PRIOR~
+       5 BRA-1~ 35/F~ C: Co~ cl A     trm A_~ 25JUL2~ 03AUG~   739 07SEP~   774 PRIOR~
+       6 BRA-1~ 35/F~ C: Co~ cl A     trm A_~ 25JUL2~ 03MAR~   951 07MAY~  1016 PRIOR~
+       7 BRA-1~ 35/F~ C: Co~ cl A     trm A_~ 25JUL2~ 10JAN~   899 28MAY~  1037 PRIOR~
+       8 BRA-1~ 35/F~ C: Co~ cl B     trm B_~ 25JUL2~ 16AUG~   387 26AUG~   397 PRIOR~
+       9 BRA-1~ 35/F~ C: Co~ cl D     trm D_~ 25JUL2~ 23JUL~  1093 25JUL~  1095 PRIOR~
+      10 BRA-1~ 35/F~ C: Co~ cl D     trm D_~ 25JUL2~ 23OCT~   455 12JUL~  1082 PRIOR~
+      # i 1,924 more rows
+

--- a/package/tests/testthat/_snaps/oncl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/oncl01/markdown-snaps.md
@@ -1,0 +1,25 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 1,200 x 9
+         ID           TRT01A        AVAL Best Confirmed Overa~1 Investigator End Of ~2
+         <lstng_ky>   <lstng_ky>   <dbl> <fct>                  <fct>                 
+       1 BRA-1/id-105 A: Drug X        7 CR                     CR                    
+       2 BRA-1/id-105 A: Drug X        7 CR                     CR                    
+       3 BRA-1/id-105 A: Drug X        7 CR                     CR                    
+       4 BRA-1/id-134 A: Drug X        7 CR                     CR                    
+       5 BRA-1/id-134 A: Drug X        7 CR                     CR                    
+       6 BRA-1/id-134 A: Drug X        7 CR                     CR                    
+       7 BRA-1/id-141 C: Combinat~     7 CR                     PR                    
+       8 BRA-1/id-141 C: Combinat~     7 CR                     PR                    
+       9 BRA-1/id-141 C: Combinat~     7 CR                     PR                    
+      10 BRA-1/id-236 B: Placebo       7 PR                     SD                    
+      # i 1,190 more rows
+      # i abbreviated names: 1: `Best Confirmed Overall Response by Investigator`,
+      #   2: `Investigator End Of Induction Response`
+      # i 4 more variables: `Overall Survival (DAYS)` <chr>,
+      #   `Progression Free Survival (DAYS)` <chr>, trigeventpfs <chr>,
+      #   `Duration of Confirmed Response (DAYS)` <chr>
+

--- a/package/tests/testthat/_snaps/vsl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/vsl01/markdown-snaps.md
@@ -1,0 +1,24 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 2,000 x 17
+         CRTNPT     AGSXRC           TRT01A AVISIT   ADY AVAL_ANRIND_WEIGHT CHG_WEIGHT
+         <lstng_ky> <lstng_ky>       <lstn> <lstn> <int> <chr>              <chr>     
+       1 BRA-1/105  38/M/BLACK OR A~ A: Dr~ WEEK ~   189 " 90.96"           "  24.62" 
+       2 BRA-1/105  38/M/BLACK OR A~ A: Dr~ WEEK ~   323 " 41.40"           " -24.93" 
+       3 BRA-1/105  38/M/BLACK OR A~ A: Dr~ WEEK ~   492 " 60.55"           "  -5.78" 
+       4 BRA-1/105  38/M/BLACK OR A~ A: Dr~ WEEK ~   550 " 69.69"           "   3.36" 
+       5 BRA-1/105  38/M/BLACK OR A~ A: Dr~ WEEK ~   628 " 81.64"           "  15.30" 
+       6 BRA-1/134  47/M/WHITE       A: Dr~ WEEK ~   203 " 42.95"           " -12.51" 
+       7 BRA-1/134  47/M/WHITE       A: Dr~ WEEK ~   326 " 20.36/L"         " -35.09" 
+       8 BRA-1/134  47/M/WHITE       A: Dr~ WEEK ~   363 " 46.33"           "  -9.12" 
+       9 BRA-1/134  47/M/WHITE       A: Dr~ WEEK ~   367 " 43.83"           " -11.62" 
+      10 BRA-1/134  47/M/WHITE       A: Dr~ WEEK ~   417 " 31.75/L"         " -23.71" 
+      # i 1,990 more rows
+      # i 10 more variables: AVAL_ANRIND_TEMP <chr>, CHG_TEMP <chr>,
+      #   AVAL_ANRIND_DIABP <chr>, CHG_DIABP <chr>, AVAL_ANRIND_SYSBP <chr>,
+      #   CHG_SYSBP <chr>, AVAL_ANRIND_PULSE <chr>, CHG_PULSE <chr>,
+      #   AVAL_ANRIND_RESP <chr>, CHG_RESP <chr>
+


### PR DESCRIPTION
Partially addresses #74 

### Scope of the PR

* Adds markdown snapshots for all the `listings/other` articles