### PR TITLE
#74 (PR 9/12) - Adding snapshots for listings/pharmacokinetic

### DIFF
--- a/book/listings/pharmacokinetic/adal02.qmd
+++ b/book/listings/pharmacokinetic/adal02.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Anti-Drug Antibody Data for Treatment Emergent ADA Positive
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -99,7 +101,7 @@ out <- out %>%
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = "USUBJID",
@@ -122,6 +124,8 @@ Asterisk denotes sample that tested positive for Neutralizing Antibodies."
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/pharmacokinetic/pkcl01.qmd
+++ b/book/listings/pharmacokinetic/pkcl01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Drug A Concentration by Treatment Group, Patient and Nomina
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -35,7 +37,7 @@ var_labels(out) <- c(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("ARM", "USUBJID", "VISIT"),
@@ -46,6 +48,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/pharmacokinetic/pkcl02.qmd
+++ b/book/listings/pharmacokinetic/pkcl02.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Drug A Urine Concentration and Volumes
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -69,7 +71,7 @@ out <- out %>% var_relabel(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("TRT01A", "USUBJID", "VISIT"),
@@ -83,6 +85,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/pharmacokinetic/pkpl01.qmd
+++ b/book/listings/pharmacokinetic/pkpl01.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Drug A Plasma PK Parameters
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -43,7 +45,7 @@ out <- out %>% var_relabel(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("TRT01A", "USUBJID", "AVISIT"),
@@ -54,6 +56,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/pharmacokinetic/pkpl02.qmd
+++ b/book/listings/pharmacokinetic/pkpl02.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Drug A Urine PK Parameters
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -44,7 +46,7 @@ out <- out %>% var_relabel(
 
 ## Standard Listing
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = c("TRT01A", "USUBJID", "AVISIT"),
@@ -55,6 +57,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/book/listings/pharmacokinetic/pkpl04.qmd
+++ b/book/listings/pharmacokinetic/pkpl04.qmd
@@ -5,6 +5,8 @@ subtitle: Listing of Individual Drug A AUCIFO and CMAX Ratios Following Drug A o
 
 ------------------------------------------------------------------------
 
+{{< include ../../test-utils/envir_hook.qmd >}}
+
 ::: panel-tabset
 ## Data Setup
 
@@ -55,7 +57,7 @@ out <- out %>% var_relabel(USUBJID = "Subject ID")
 
 ## Standard Listing - CYCLE 1 DAY 1
 
-```{r}
+```{r lsting, test = list(lsting = "lsting")}
 lsting <- as_listing(
   out,
   key_cols = "USUBJID",
@@ -70,6 +72,8 @@ lsting <- as_listing(
 
 head(lsting, 20)
 ```
+
+{{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../si.qmd >}}
 :::

--- a/package/tests/testthat/_snaps/adal02/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/adal02/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 134 x 3
+         USUBJID               `Day 2\n(Day 1)` PTES    
+         <lstng_ky>            <chr>            <chr>   
+       1 AB12345-BRA-1-id-105  ---              Enhanced
+       2 AB12345-BRA-1-id-134  ---              Enhanced
+       3 AB12345-BRA-1-id-42   ---              Enhanced
+       4 AB12345-BRA-1-id-93   ---              Enhanced
+       5 AB12345-BRA-11-id-217 ---              Enhanced
+       6 AB12345-BRA-11-id-345 ---              Enhanced
+       7 AB12345-BRA-11-id-397 ---              Enhanced
+       8 AB12345-BRA-11-id-50  ---              Enhanced
+       9 AB12345-BRA-13-id-177 ---              Enhanced
+      10 AB12345-BRA-14-id-23  ---              Enhanced
+      # i 124 more rows
+

--- a/package/tests/testthat/_snaps/pkcl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkcl01/markdown-snaps.md
@@ -1,0 +1,20 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 2,660 x 6
+         ARM        USUBJID              VISIT      NFRLT AFRLT   AVAL
+         <lstng_ky> <lstng_ky>           <lstng_ky> <dbl> <dbl>  <dbl>
+       1 A: Drug X  AB12345-BRA-1-id-105 Day 1        0     0    0    
+       2 A: Drug X  AB12345-BRA-1-id-105 Day 1        0.5   0.5 10.4  
+       3 A: Drug X  AB12345-BRA-1-id-105 Day 1        1     1   14.0  
+       4 A: Drug X  AB12345-BRA-1-id-105 Day 1        1.5   1.5 14.1  
+       5 A: Drug X  AB12345-BRA-1-id-105 Day 1        2     2   12.7  
+       6 A: Drug X  AB12345-BRA-1-id-105 Day 1        3     3    8.80 
+       7 A: Drug X  AB12345-BRA-1-id-105 Day 1        4     4    5.46 
+       8 A: Drug X  AB12345-BRA-1-id-105 Day 1        8     8    0.562
+       9 A: Drug X  AB12345-BRA-1-id-105 Day 1       12    12    0.049
+      10 A: Drug X  AB12345-BRA-1-id-105 Day 2       24    24    0    
+      # i 2,650 more rows
+

--- a/package/tests/testthat/_snaps/pkcl02/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkcl02/markdown-snaps.md
@@ -1,0 +1,26 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 532 x 13
+         TRT01A     USUBJID        VISIT UR_Conc (ug/mL) -\nU~1 Vurine (mL) -\nUrine~2
+         <lstng_ky> <lstng_ky>     <lst>                  <dbl>                  <dbl>
+       1 A: Drug X  AB12345-BRA-1~ Day 1                      0                   714.
+       2 A: Drug X  AB12345-BRA-1~ Day 2                     NA                    NA 
+       3 A: Drug X  AB12345-BRA-1~ Day 1                      0                  1069.
+       4 A: Drug X  AB12345-BRA-1~ Day 2                     NA                    NA 
+       5 A: Drug X  AB12345-BRA-1~ Day 1                      0                   817.
+       6 A: Drug X  AB12345-BRA-1~ Day 2                     NA                    NA 
+       7 A: Drug X  AB12345-BRA-1~ Day 1                      0                   865.
+       8 A: Drug X  AB12345-BRA-1~ Day 2                     NA                    NA 
+       9 A: Drug X  AB12345-BRA-1~ Day 1                      0                   725.
+      10 A: Drug X  AB12345-BRA-1~ Day 2                     NA                    NA 
+      # i 522 more rows
+      # i abbreviated names:
+      #   1: `UR_Conc (ug/mL) -\nUrine Collection\nInterval:\nredose`,
+      #   2: `Vurine (mL) -\nUrine Collection\nInterval:\nredose`
+      # i 8 more variables:
+      #   `UR_Conc (ug/mL) -\nUrine Collection\nInterval (hours):\n0 - 4` <dbl>,
+      #   `Vurine (mL) -\nUrine Collection\nInterval (hours):\n0 - 4` <dbl>, ...
+

--- a/package/tests/testthat/_snaps/pkpl01/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpl01/markdown-snaps.md
@@ -1,0 +1,22 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 798 x 6
+         TRT01A     USUBJID           AVISIT AUC Infinity Obs (da~1 `Max Conc (ug/mL)`
+         <lstng_ky> <lstng_ky>        <lstn>                  <dbl>              <dbl>
+       1 A: Drug X  AB12345-BRA-1-id~ SCREE~                   145.               35.5
+       2 A: Drug X  AB12345-BRA-1-id~ CYCLE~                   246.               31.2
+       3 A: Drug X  AB12345-BRA-1-id~ CYCLE~                   225.               43.5
+       4 A: Drug X  AB12345-BRA-1-id~ SCREE~                   157.               32.1
+       5 A: Drug X  AB12345-BRA-1-id~ CYCLE~                   249.               21.8
+       6 A: Drug X  AB12345-BRA-1-id~ CYCLE~                   231.               21.1
+       7 A: Drug X  AB12345-BRA-1-id~ SCREE~                   194.               20.5
+       8 A: Drug X  AB12345-BRA-1-id~ CYCLE~                   211.               26.8
+       9 A: Drug X  AB12345-BRA-1-id~ CYCLE~                   168.               34.8
+      10 A: Drug X  AB12345-BRA-1-id~ SCREE~                   187.               27.4
+      # i 788 more rows
+      # i abbreviated name: 1: `AUC Infinity Obs (day*ug/mL)`
+      # i 1 more variable: `Total CL Obs (ml/day/kg)` <dbl>
+

--- a/package/tests/testthat/_snaps/pkpl02/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpl02/markdown-snaps.md
@@ -1,0 +1,23 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 798 x 7
+         TRT01A     USUBJID            AVISIT `Renal CL (L/hr)` Renal CL Norm by Dos~1
+         <lstng_ky> <lstng_ky>         <lstn>             <dbl>                  <dbl>
+       1 A: Drug X  AB12345-BRA-1-id-~ SCREE~            0.0538                0.00442
+       2 A: Drug X  AB12345-BRA-1-id-~ CYCLE~            0.0481                0.00418
+       3 A: Drug X  AB12345-BRA-1-id-~ CYCLE~            0.0524                0.00575
+       4 A: Drug X  AB12345-BRA-1-id-~ SCREE~            0.0548                0.00489
+       5 A: Drug X  AB12345-BRA-1-id-~ CYCLE~            0.0464                0.00281
+       6 A: Drug X  AB12345-BRA-1-id-~ CYCLE~            0.0543                0.00480
+       7 A: Drug X  AB12345-BRA-1-id-~ SCREE~            0.0480                0.00621
+       8 A: Drug X  AB12345-BRA-1-id-~ CYCLE~            0.0601                0.00424
+       9 A: Drug X  AB12345-BRA-1-id-~ CYCLE~            0.0222                0.00415
+      10 A: Drug X  AB12345-BRA-1-id-~ SCREE~            0.0429                0.00451
+      # i 788 more rows
+      # i abbreviated name: 1: `Renal CL Norm by Dose (L/hr/mg)`
+      # i 2 more variables: `Amt Rec from T1 to T2 (mg)` <dbl>,
+      #   `Pct Rec from T1 to T2 (%)` <dbl>
+

--- a/package/tests/testthat/_snaps/pkpl04/markdown-snaps.md
+++ b/package/tests/testthat/_snaps/pkpl04/markdown-snaps.md
@@ -1,0 +1,26 @@
+# lsting
+
+    Code
+      print(data_snap[[i]])
+    Output
+      # A tibble: 266 x 7
+         USUBJID  AUC Infinity Obs (da~1 AUC Infinity Obs (da~2 AUC Infinity Obs (da~3
+         <lstng_>                  <dbl>                  <dbl>                  <dbl>
+       1 AB12345~                   246.                    NA                  NA    
+       2 AB12345~                   249.                    NA                  NA    
+       3 AB12345~                   204.                   192.                  1.06 
+       4 AB12345~                   196.                   219.                  0.898
+       5 AB12345~                   211.                    NA                  NA    
+       6 AB12345~                   160.                    NA                  NA    
+       7 AB12345~                   218.                   181.                  1.20 
+       8 AB12345~                   272.                    NA                  NA    
+       9 AB12345~                   148.                   194.                  0.765
+      10 AB12345~                   206.                   216.                  0.952
+      # i 256 more rows
+      # i abbreviated names: 1: `AUC Infinity Obs (day*ug/mL)\nPlasma Drug X`,
+      #   2: `AUC Infinity Obs (day*ug/mL)\nPlasma Drug Y`,
+      #   3: `AUC Infinity Obs (day*ug/mL)\nPlasma Drug X/Plasma Drug Y`
+      # i 3 more variables: `Max Conc (ug/mL)\nPlasma Drug X` <dbl>,
+      #   `Max Conc (ug/mL)\nPlasma Drug Y` <dbl>,
+      #   `Max Conc (ug/mL)\nPlasma Drug X/Plasma Drug Y` <dbl>
+


### PR DESCRIPTION
Partially addresses #74 

### Scope of the PR

* Adds markdown snapshots for all the `listings/pharmacokinetic` articles