### PR TITLE
Fix cancelled R CMD check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,21 +21,22 @@ jobs:
     name: Audit Dependencies 🕵️‍♂️
     uses: insightsengineering/r.pkg.template/.github/workflows/audit.yaml@main
   r-cmd:
-   name: R CMD Check 🧬
-   uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
-   secrets:
-     REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
-   with:
-     package-subdirectory: package
-     additional-env-vars: |
-       _R_CHECK_CRAN_INCOMING_REMOTE_=false
-     additional-r-cmd-check-params: --as-cran
-     enforce-note-blocklist: true
-     note-blocklist: |
-       checking dependencies in R code ... NOTE
-       checking R code for possible problems ... NOTE
-       checking examples ... NOTE
-       checking Rd line widths ... NOTE
+    if: github.event_name != 'push'
+    name: R CMD Check 🧬
+    uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+    with:
+      package-subdirectory: package
+      additional-env-vars: |
+        _R_CHECK_CRAN_INCOMING_REMOTE_=false
+      additional-r-cmd-check-params: --as-cran
+      enforce-note-blocklist: true
+      note-blocklist: |
+        checking dependencies in R code ... NOTE
+        checking R code for possible problems ... NOTE
+        checking examples ... NOTE
+        checking Rd line widths ... NOTE
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️


### PR DESCRIPTION
When merging/pushing to `main`, both `check.yaml` and `docs.yaml` workflows run.

Example: [`check.yaml`](https://github.com/insightsengineering/tlg-catalog/actions/runs/7023448969) and [`docs.yaml`](https://github.com/insightsengineering/tlg-catalog/actions/runs/7023448897).

This causes the R CMD check job in `check.yaml` workflow to take precedence over the R CMD check job (for stable package versions) in `docs.yaml` workflow (which is responsible for checking the Catalog prior to rendering it for stable package versions). The R CMD check job in `docs.yaml` is then cancelled and the Catalog will not be rendered for stable package versions even if the R CMD check succeeded.

The proposed solution is to only run the R CMD check job in `docs.yaml` on push to `main`.