### PR TITLE
Update image used for rendering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build & Deploy TLGC (dev) 📖
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/insightsengineering/rstudio_4.3.1_bioc_3.17:latest
+      image: ghcr.io/insightsengineering/rstudio:latest
     permissions:
       contents: write
     steps:
@@ -129,7 +129,7 @@ jobs:
     name: Build & Deploy TLGC (stable) 📖
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/insightsengineering/rstudio_4.3.1_bioc_3.17:latest
+      image: ghcr.io/insightsengineering/rstudio:latest
     permissions:
       contents: write
     needs: r-cmd-stable


### PR DESCRIPTION
Rendering of TLG Catalog fails because of e.g. outdated `mmrm` version in the image used ([example](https://github.com/insightsengineering/tlg-catalog/actions/runs/7278743628/job/19833579622)).