### PR TITLE
force render all articles

### DIFF
--- a/book/_quarto.yml
+++ b/book/_quarto.yml
@@ -35,8 +35,8 @@ format:
     page-layout: full
 
 execute:
-  freeze: auto
-  cache: true
+  freeze: false
+  cache: false
   code-line-numbers: true
 
 knitr:


### PR DESCRIPTION
When reading the logs from deployment I noticed that only part of the articles are being rendered. Few examples from the latest build:
- https://github.com/insightsengineering/tlg-catalog/actions/runs/7395605763/job/20119087165#step:7:492
- https://github.com/insightsengineering/tlg-catalog/actions/runs/7395605763/job/20119087165#step:7:525
- https://github.com/insightsengineering/tlg-catalog/actions/runs/7395605763/job/20119087165#step:7:687

We do want to render (cover) all the articles so as to test sufficiently against changes in the packages used. This PR aims to force render all. I hope this is enough.  
This is desirable for both stable and devel profile so changes in the _main_ config file.

Relevant docs: 
https://quarto.org/docs/projects/code-execution.html#freeze
https://quarto.org/docs/projects/code-execution.html#cache