### PR TITLE
Linter cleanup of on `pre-commit`

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,13 @@
 linters: linters_with_defaults(
-  line_length_linter = line_length_linter(120),
+  line_length_linter = line_length_linter(120L),
   cyclocomp_linter = NULL,
   object_usage_linter = NULL,
-  object_name_linter = NULL
+  object_name_linter = object_name_linter(
+    styles = c("snake_case", "symbols"),
+    regexes = c(
+      ANL = "^ANL_?[0-9A-Z_]*$",
+      ADaM = "^r?AD[A-Z]{2,5}_?[0-9]*$",
+      ADaM_variables = "^AVAL$|^USUBJID$|^PARAMCD$|^PARAM$"
+      )
+    )
   )

--- a/book/generate-index.R
+++ b/book/generate-index.R
@@ -13,7 +13,7 @@ print_ref_templates <- function(fpath) {
 
 section_header <- function(title) {
   cat(
-    paste("", "------------------------------------------------------------------------", "", # nolint
+    paste("", "------------------------------------------------------------------------", "",
       paste0("### ", "**", title, "**"), "",
       sep = "\n"
     ),
@@ -22,7 +22,7 @@ section_header <- function(title) {
 }
 
 create_subsection <- function(fpath, title) {
-  cat(paste("", paste("####", title), "", "", sep = "\n"), file = "./tlg-index.qmd", append = TRUE) # nolint
+  cat(paste("", paste("####", title), "", "", sep = "\n"), file = "./tlg-index.qmd", append = TRUE)
   all_files <- list.files(path = fpath, pattern = "*.qmd", full.names = TRUE)
   invisible(sapply(all_files, print_ref_templates))
 }
@@ -30,7 +30,7 @@ create_subsection <- function(fpath, title) {
 # Create Index Header
 
 cat(
-  paste("---", "title: Index", "toc: true", "toc-depth: 4", "---", "", sep = "\n"), # nolint
+  paste("---", "title: Index", "toc: true", "toc-depth: 4", "---", "", sep = "\n"),
   file = "./tlg-index.qmd"
 )
 
@@ -59,9 +59,9 @@ create_subsection("./tables/vital-signs", "Vital Signs")
 section_header("Listings")
 create_subsection("./listings/ADA", "ADA")
 create_subsection("./listings/adverse-events", "Adverse Events")
-create_subsection("./listings/concomitant-medications", "Concomitant Medications") # nolint
+create_subsection("./listings/concomitant-medications", "Concomitant Medications")
 create_subsection("./listings/disposition", "Disposition")
-create_subsection("./listings/development-safety-update-report", "Development Safety Update Report") # nolint
+create_subsection("./listings/development-safety-update-report", "Development Safety Update Report")
 create_subsection("./listings/ECG", "ECG")
 create_subsection("./listings/exposure", "Exposure")
 create_subsection("./listings/lab-results", "Lab Results")

--- a/book/graphs/efficacy/fstg02.qmd
+++ b/book/graphs/efficacy/fstg02.qmd
@@ -163,7 +163,7 @@ plot
 ```{r test parameters, test = list(width = "width", height = "height", plot_v3.width = "plot_v3.width"), echo=FALSE}
 width <- 15
 height <- 4
-plot_v3.width <- 8
+plot_v3.width <- 8 # nolint: object_name.
 ```
 
 {{< include ../../test-utils/save_results.qmd >}}

--- a/book/graphs/other/brg01.qmd
+++ b/book/graphs/other/brg01.qmd
@@ -121,6 +121,7 @@ plot
 ## Plot of Percentage <br/> and Confidence Intervals
 
 <!-- skip strict because of partial arg match in `bionom` https://github.com/cran/binom/blob/master/R/binom.confint.R#L31 -->
+
 ```{r plot5, test = list(plot_v5 = "plot"), opts.label = c('skip_test_strict')}
 anl <- adlb %>%
   filter(PARAMCD == "ALT" & ANRIND == "HIGH")
@@ -138,7 +139,7 @@ anlpop <- as.data.frame(table(anl$ANRIND, anl$ACTARM)) %>%
   select(ACTARM, EVENTCOUNT)
 
 anl <- left_join(patpop5, anlpop, by = "ACTARM")
-CIs <- binom.confint(x = anl$EVENTCOUNT, n = anl$TRTPOP, methods = "exact")
+CIs <- binom.confint(x = anl$EVENTCOUNT, n = anl$TRTPOP, methods = "exact") # nolint: object_name.
 anl <- cbind(anl, CIs[, 4:6])
 
 plot <- ggplot(anl) +
@@ -314,5 +315,4 @@ plot
 ```
 
 {{< include ../../repro.qmd >}}
-
 :::

--- a/book/graphs/pharmacokinetic/pkpg01.qmd
+++ b/book/graphs/pharmacokinetic/pkpg01.qmd
@@ -45,7 +45,7 @@ levels(adpp$ARM) <- c(
 ## Plot with Two Cohorts
 
 ```{r plot1, test = list(plot_v1 = "plot")}
-use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint line_length_linter
+use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint: line_length. line_length_linter
 use_subtitle <- "Analyte: Plasma Drug X \nVisit: CYCLE 1 DAY 1 \nPK Parameter:"
 use_footnote <- "Program: \nOutput:"
 
@@ -101,7 +101,7 @@ adpp_hck <- adpp %>%
 
 adpp <- bind_rows(adpp, adpp_hck)
 
-use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint line_length_linter
+use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint: line_length_linter.
 use_subtitle <- "Analyte: Plasma Drug X \nVisit: CYCLE 1 DAY 1 \nPK Parameter:"
 use_footnote <- "Program: \nOutput:"
 

--- a/book/graphs/pharmacokinetic/pkpg01.qmd
+++ b/book/graphs/pharmacokinetic/pkpg01.qmd
@@ -101,7 +101,7 @@ adpp_hck <- adpp %>%
 
 adpp <- bind_rows(adpp, adpp_hck)
 
-use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint: line_length_linter.
+use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint: line_length.
 use_subtitle <- "Analyte: Plasma Drug X \nVisit: CYCLE 1 DAY 1 \nPK Parameter:"
 use_footnote <- "Program: \nOutput:"
 

--- a/book/graphs/pharmacokinetic/pkpg01.qmd
+++ b/book/graphs/pharmacokinetic/pkpg01.qmd
@@ -45,7 +45,7 @@ levels(adpp$ARM) <- c(
 ## Plot with Two Cohorts
 
 ```{r plot1, test = list(plot_v1 = "plot")}
-use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint: line_length. line_length_linter
+use_title <- "Plot of Mean (+/- SD) Cummulative Percentage (%) of Recovered Drug in Urine \nby Analyte, Visit: PK Evaluable Patients" # nolint: line_length.
 use_subtitle <- "Analyte: Plasma Drug X \nVisit: CYCLE 1 DAY 1 \nPK Parameter:"
 use_footnote <- "Program: \nOutput:"
 

--- a/book/graphs/pharmacokinetic/pkpg02.qmd
+++ b/book/graphs/pharmacokinetic/pkpg02.qmd
@@ -51,12 +51,12 @@ y_var <- "AUCinf"
 
 ## Summary of Pharmacokinetic <br/> Parameters -- Plasma
 
-```{r plot1, test = list(plot_v1 = "plot")}
+```{r plot1, test = list(plot_v1 = "plot"), opts.label=c("remove_linter")}
 # calculate Summary Statistics (mean and sd) for each group
-SummaryStat <- adpp_adex %>%
+SummaryStat <- adpp_adex %>% # nolint: object_name.
   group_by(Dose = as.factor(Dose)) %>%
   summarise(AUCsd = sd(AUCinf), meanAUC = mean(AUCinf))
-SummaryStat$Dose <- as.numeric(as.character(SummaryStat$Dose))
+SummaryStat$Dose <- as.numeric(as.character(SummaryStat$Dose)) # nolint: object_name.
 
 # generate linear model
 mod1 <- lm(log(AUCinf) ~ log(Dose), adpp_adex)
@@ -115,10 +115,10 @@ plot
 
 ```{r plot2, test = list(plot_v2 = "plot")}
 # calculate median for each group if preferred
-SummaryStat <- adpp_adex %>%
+SummaryStat <- adpp_adex %>% # nolint: object_name.
   group_by(Dose = as.factor(Dose)) %>%
   summarise(medAUC = median(AUCinf))
-SummaryStat$Dose <- as.numeric(as.character(SummaryStat$Dose))
+SummaryStat$Dose <- as.numeric(as.character(SummaryStat$Dose)) # nolint: object_name.
 
 plot <- ggplot(adpp_adex, aes(x = .data[[x_var]], y = .data[[y_var]])) +
   annotate(geom = "text", x = min(adpp_adex[[x_var]]), y = max(adpp_adex[[y_var]]), label = eq, hjust = 0.1) +
@@ -162,5 +162,4 @@ plot
 ```
 
 {{< include ../../repro.qmd >}}
-
 :::

--- a/book/listings/ADA/adal02.qmd
+++ b/book/listings/ADA/adal02.qmd
@@ -111,7 +111,7 @@ lsting <- as_listing(
     "\nProtocol: ", unique(adab$PARCAT1)[1]
   ),
   subtitles = paste("\nTreatment Group:", trt),
-  # nolint start line_length_linter
+  # nolint start: line_length.
   main_footer = "Minimum reportable titer = 1.10 (example only)
 --- = No sample evaluated
 ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies)
@@ -121,7 +121,7 @@ Treatment-enhanced ADA = a patient with positive ADA result at baseline who has 
 Transient ADA = ADA positive result detected (a) at only one post-baseline sampling timepoint (excluding last timepoint) OR (b) at 2 or more timepoints during treatment where the first and last ADA positive samples  are separated by a period of < 16 weeks, irrespective of any negative samples in between.
 Persistent ADA =  ADA positive result detected (a) at the last post-baseline sampling timepoint, OR (b) at 2 or more time points during treatment where the first and last ADA positive samples are separated by a period ≥ 16 weeks, irrespective of any negative samples in between.
 Asterisk denotes sample that tested positive for Neutralizing Antibodies."
-  # nolint end
+  # nolint end: line_length.
 )
 
 head(lsting, 20)

--- a/book/listings/ECG/egl01.qmd
+++ b/book/listings/ECG/egl01.qmd
@@ -88,7 +88,7 @@ lsting <- as_listing(
   key_cols = c("TRT01A", "CRTNPT", "AGSXRC", "AVISIT", "ADY"),
   disp_cols = names(out),
   main_title = "Listing of ECG Data: Safety-Evaluable Patients",
-  main_footer = "Baseline is the patient's last observation prior to initiation of study drug. Abnormalities are flagged as high (H) or low (L) if outside the Roche standard reference range." # nolint line_length_linter
+  main_footer = "Baseline is the patient's last observation prior to initiation of study drug. Abnormalities are flagged as high (H) or low (L) if outside the Roche standard reference range." # nolint: line_length.
 )
 
 head(lsting, 20)

--- a/book/listings/lab-results/lbl01_rls.qmd
+++ b/book/listings/lab-results/lbl01_rls.qmd
@@ -77,7 +77,7 @@ lsting <- as_listing(
   key_cols = c("TRT01A", "CPID"),
   disp_cols = names(out),
   main_title = "Listing of Laboratory Test Results Using Roche Safety Lab Standardization",
-  main_footer = "Abnormalities are flagged as high (H) or low (L) if outside the Roche standard reference range; high high (HH) or low low (LL) if outside the Roche marked reference range with a clinically relevant change from baseline. " # nolint line_length_linter
+  main_footer = "Abnormalities are flagged as high (H) or low (L) if outside the Roche standard reference range; high high (HH) or low low (LL) if outside the Roche marked reference range with a clinically relevant change from baseline. " # nolint: line_length.
 )
 
 head(lsting, 20)

--- a/book/listings/lab-results/lbl02a_rls.qmd
+++ b/book/listings/lab-results/lbl02a_rls.qmd
@@ -92,7 +92,7 @@ lsting <- as_listing(
   key_cols = c("TRT01A", "LBTEST_U", "CPID"),
   disp_cols = names(out),
   main_title = "Listing of Laboratory Abnormalities Defined by Roche Safety Lab Standardization",
-  main_footer = "Standard reference range, marked reference range and clinically relevant change from baseline are from the Roche Safety Lab Standardization guideline.  Abnormalities are flagged as high (H) or low (L) if outside the standard reference range; high high (HH) or low low (LL) if outside the marked reference range with a clinically relevant change from baseline." # nolint line_length_linter
+  main_footer = "Standard reference range, marked reference range and clinically relevant change from baseline are from the Roche Safety Lab Standardization guideline.  Abnormalities are flagged as high (H) or low (L) if outside the standard reference range; high high (HH) or low low (LL) if outside the marked reference range with a clinically relevant change from baseline." # nolint: line_length.
 )
 
 head(lsting, 20)

--- a/book/listings/vital-signs/vsl01.qmd
+++ b/book/listings/vital-signs/vsl01.qmd
@@ -121,7 +121,7 @@ lsting <- as_listing(
   key_cols = c("TRT01A", "CRTNPT", "AGSXRC", "AVISIT"),
   disp_cols = names(out),
   main_title = "Listing of Vital Signs: Safety-Evaluable Patients",
-  main_footer = "Baseline is the patient's last observation prior to initiation of study drug. Abnormalities are flagged as high (H) or low (L) if outside the Roche standard reference range." # nolint line_length_linter
+  main_footer = "Baseline is the patient's last observation prior to initiation of study drug. Abnormalities are flagged as high (H) or low (L) if outside the Roche standard reference range." # nolint: line_length.
 )
 
 head(lsting, 20)

--- a/book/tables/ADA/adat01.qmd
+++ b/book/tables/ADA/adat01.qmd
@@ -223,7 +223,7 @@ result <- cbind_rtables(result[, 1], result[, 3]) %>%
 main_title(result) <- paste(
   "Baseline Prevalence and Incidence of Treatment Emergent ADA"
 )
-# nolint start line_length_linter
+# nolint start: line_length.
 main_footer(result) <- "ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies) Baseline evaluable patient = a patient with an ADA assay result from a baseline sample(s)
   Post-baseline evaluable patient = a patient with an ADA assay result from at least one post-baseline sample Number of patients positive for Treatment Emergent
   ADA = the number (and percentage) of post-baseline evaluable patients determined to have treatment-induced ADA or treatment-enhanced ADA during the study period.
@@ -232,7 +232,7 @@ main_footer(result) <- "ADA = Anti-Drug Antibodies (is also referred to as ATA, 
   Number of patients negative for Treatment Emergent ADA = number of post-baseline evaluable patients with negative or missing baseline ADA result(s) and all negative post-baseline results, or a patient who is treatment unaffected.
   Treatment unaffected = A post-baseline evaluable patient with a positive ADA result at baseline and (a) where all post-baseline titer results are less than 0.60 t.u. greater than the baseline titer result, OR (b) where all post-baseline results are negative or missing.
   For any positive sample with titer result less than the minimum reportable titer or any positive sample where a titer cannot be obtained, titer value is imputed as equal to the minimum reportable titer."
-# nolint end
+# nolint end: line_length.
 result
 ```
 

--- a/book/tables/ADA/adat03.qmd
+++ b/book/tables/ADA/adat03.qmd
@@ -108,8 +108,8 @@ main_title(result) <- paste(
   Protocol:", unique(adab$PARCAT1)[1]
 )
 subtitles(result) <- paste("Analyte:", unique(adab$PARAMCD)[1])
-fnotes_at_path(result, rowpath = NULL, colpath = c("multivars", "AVAL")) <- "Refers to the total no. of measurable ADA samples that have a corresponding measurable drug concentration sample (i.e. results with valid numeric values and LTRs). LTR results on post-dose samples are replaced by aaa µg/mL i.e. half of MQC value." # nolint line_length_linter
-fnotes_at_path(result, rowpath = NULL, colpath = c("multivars", "AVAL_LT")) <- "In validation, the assay was able to detect yyy ng/mL of surrogate ADA in the presence of zzz µg/mL of [drug]. BLQ = Below Limit of Quantitation, LTR = Lower than Reportable, MQC = Minimum Quantifiable Concentration, ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies). RXXXXXXX is also known as [drug]" # nolint line_length_linter
+fnotes_at_path(result, rowpath = NULL, colpath = c("multivars", "AVAL")) <- "Refers to the total no. of measurable ADA samples that have a corresponding measurable drug concentration sample (i.e. results with valid numeric values and LTRs). LTR results on post-dose samples are replaced by aaa µg/mL i.e. half of MQC value." # nolint: line_length.
+fnotes_at_path(result, rowpath = NULL, colpath = c("multivars", "AVAL_LT")) <- "In validation, the assay was able to detect yyy ng/mL of surrogate ADA in the presence of zzz µg/mL of [drug]. BLQ = Below Limit of Quantitation, LTR = Lower than Reportable, MQC = Minimum Quantifiable Concentration, ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies). RXXXXXXX is also known as [drug]" # nolint: line_length.
 
 result
 ```

--- a/book/tables/ADA/adat04a.qmd
+++ b/book/tables/ADA/adat04a.qmd
@@ -248,7 +248,7 @@ main_title(result) <- paste(
   "Baseline Prevalence and Incidence of Treatment Emergent NAbs"
 )
 subtitles(result) <- paste("Protocol:", unique(adab$PARCAT1)[1])
-# nolint start line_length_linter
+# nolint start: line_length.
 main_footer(result) <- "NAb = Neutralizing Antibodies ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies) Baseline evaluable patient for ADA = a patient with an ADA assay result from a baseline sample(s)
   Baseline evaluable patient for NAb = a patient with a NAb assay result from a baseline sample(s)
   Post-baseline evaluable patient for ADA = a patient with an ADA assay result from at least one post-baseline sample
@@ -258,7 +258,7 @@ Number of patients positive for Treatment Emergent NAb = the number (and percent
 Treatment-induced = a patient with negative or missing baseline result(s) and at least one positive post-baseline result. Treatment-enhanced = a patient with positive result at baseline who has one or more post-baseline titer results that are at least 0.60 t.u. greater than the baseline titer result.
 Number of patients negative for Treatment Emergent NAb = number of post-baseline evaluable patients with negative or missing baseline NAb result(s) and all negative post-baseline NAb results, or a patient who is NAb treatment unaffected.
 Treatment unaffected = A post-baseline evaluable patient with a positive result at baseline and (a) where all post-baseline titer results are less than 0.60 t.u. greater than the baseline titer result, OR (b) where all post-baseline results are negative or missing. For any positive sample with titer result less than the minimum reportable titer or any positive sample where a titer cannot be obtained, titer value is imputed as equal to the minimum reportable titer."
-# nolint end
+# nolint end: line_length.
 result
 ```
 

--- a/book/tables/ADA/adat04b.qmd
+++ b/book/tables/ADA/adat04b.qmd
@@ -214,10 +214,10 @@ main_title(result) <- paste(
   "Baseline Prevalence and Incidence of Neutralizing Antibodies (NAbs)"
 )
 subtitles(result) <- paste("Protocol:", unique(adab$PARCAT1)[1])
-# nolint start line_length_linter
+# nolint start: line_length.
 main_footer(result) <- "NAb = Neutralizing Antibodies ADA = Anti-Drug Antibodies (is also referred to as ATA, or Anti-Therapeutic Antibodies) Baseline evaluable patient for ADA = a patient with an ADA assay result from a baseline sample(s) Baseline evaluable patient for NAb = a patient with a NAb assay result from a baseline sample(s) Post-baseline evaluable patient for ADA = a patient with an ADA assay result from at least one post-baseline sample Post-baseline evaluable patient for NAb = a patient with a NAb assay result from at least one post-baseline sample Number of patients positive for ADA = the number of post-baseline evaluable patients for ADA determined to have Treatment Emergent ADA during the study period.
 Number of patients positive for NAb = the number (and percentage) of post-baseline evaluable patients for ADA determined to have at least one positive post-baseline NAb result during the study period. Number of patients negative for NAb = number of post-baseline evaluable patients with all negative post-baseline NAb results."
-# nolint end
+# nolint end: line_length.
 result
 ```
 

--- a/book/tables/disclosures/disclosurest01.qmd
+++ b/book/tables/disclosures/disclosurest01.qmd
@@ -274,7 +274,7 @@ split_fun <- drop_split_levels
 lyt <- basic_table() %>%
   split_cols_by("ARM") %>%
   summarize_patients_events_in_cols(
-    custom_label = "Total number of patients with at least one non-serious adverse event occuring at a relative frequency of >=5%" # nolint line_length_linter
+    custom_label = "Total number of patients with at least one non-serious adverse event occuring at a relative frequency of >=5%" # nolint: line_length.
   ) %>%
   split_rows_by("AEBODSYS",
     nested = FALSE,
@@ -383,5 +383,4 @@ result
 {{< include ../../test-utils/save_results.qmd >}}
 
 {{< include ../../repro.qmd >}}
-
 :::

--- a/book/tables/disclosures/eudrat01.qmd
+++ b/book/tables/disclosures/eudrat01.qmd
@@ -72,7 +72,7 @@ split_fun <- drop_split_levels
 lyt <- basic_table() %>%
   split_cols_by("ARM") %>%
   summarize_patients_events_in_cols(
-    custom_label = "Total number of patients with at least one non-serious adverse event occuring at a relative frequency of >=5% and number of events" # nolint line_length_linter
+    custom_label = "Total number of patients with at least one non-serious adverse event occuring at a relative frequency of >=5% and number of events" # nolint: line_length.
   ) %>%
   split_rows_by("AEBODSYS",
     nested = FALSE,
@@ -101,5 +101,4 @@ result
 ```
 
 {{< include ../../repro.qmd >}}
-
 :::

--- a/book/test-utils/envir_hook.qmd
+++ b/book/test-utils/envir_hook.qmd
@@ -38,4 +38,8 @@ knitr::opts_template$set(
     cache = FALSE
   )
 )
+
+knitr::opts_chunk$set(
+  tidy = function(code, ...) gsub(pattern = "#\\s?nolint.*", replacement = "", code)
+)
 ```

--- a/book/test-utils/envir_hook.qmd
+++ b/book/test-utils/envir_hook.qmd
@@ -38,8 +38,4 @@ knitr::opts_template$set(
     cache = FALSE
   )
 )
-
-knitr::opts_chunk$set(
-  tidy = function(code, ...) gsub(pattern = "#\\s?nolint.*", replacement = "", code)
-)
 ```


### PR DESCRIPTION
#### Changes description

- Add rule to object names that is CDISC and `ANL` variable friendly
- Convert all `# nolint` to specific rules
- Adds default option to all chunks that will remove any `# nolint` from code in Quarto

Superlinter runs fine on this branch: https://github.com/insightsengineering/tlg-catalog/actions/runs/8111598641/job/22171154040
  - The other linter job always fails on workflow dispatch

Running `lintr::lint_dir(".")` passes without any issues

![image](https://github.com/insightsengineering/tlg-catalog/assets/211358/0e71fb3d-ce6b-484f-be65-18cf4eb9b0f3)
