### PR TITLE
more robust test knitr template

### DIFF
--- a/book/test-utils/envir_hook.qmd
+++ b/book/test-utils/envir_hook.qmd
@@ -2,15 +2,25 @@
 #| renv.ignore: TRUE
 
 knitr::knit_hooks$set(test = function(options, envir, before = FALSE) {
+  if (isFALSE(options$eval)) {
+    return(NULL)
+  }
   if (isFALSE(testthat::is_checking() || testthat::is_testing())) {
     return(NULL)
   }
   if (isFALSE(before)) {
-    if (!exists("tenv", envir = envir)) {
+    if (isFALSE(exists("tenv", envir = envir))) {
       envir$tenv <- new.env()
     }
     for (i in seq_along(options$test)) {
-      expr <- substitute(tenv$id <- var, list(id = names(options$test)[i], var = as.name(options$test[[i]])))
+      new_name <- names(options$test)[i]
+      old_name <- options$test[[i]]
+
+      if (isFALSE(exists(old_name, envir = envir))) {
+        stop(sprintf("'%s' object not found. Please check 'test' template arguments.", old_name))
+      }
+
+      expr <- substitute(tenv$id <- var, list(id = new_name, var = as.name(old_name)))
       eval(expr, envir = envir)
     }
   }


### PR DESCRIPTION
fix the following error:

```
[103/144] tables/efficacy/ratet01.qmd
  
  
  processing file: ratet01.qmd
  
  
  
  Quitting from lines 34-88 [variant1] (ratet01.qmd)
  Error:
  ! object 'result' not found
  Execution halted
  Error in `FUN()`:
  ! In path: "/__w/tlg-catalog/tlg-catalog/tlg.catalog.pkg.Rcheck/tests/testthat/setup.R"
  Caused by error:
  ! System command 'quarto' failed
  Backtrace:
       ▆
    1. ├─testthat::test_check(pkg_name, reporter = reporter)
    2. │ └─testthat::test_dir(...)
    3. │   └─testthat:::test_files(...)
    4. │     └─testthat:::test_files_serial(...)
    5. │       └─testthat:::test_files_setup_state(...)
    6. │         └─testthat::source_test_setup(".", env)
    7. │           └─testthat::source_dir(path, "^setup.*\\.[rR]$", env = env, wrap = FALSE)
    8. │             └─base::lapply(...)
    9. │               └─testthat (local) FUN(X[[i]], ...)
   10. │                 └─testthat::source_file(path, env = env, chdir = chdir, wrap = wrap)
   11. │                   ├─base::withCallingHandlers(...)
   12. │                   └─base::eval(exprs, env)
   13. │                     └─base::eval(exprs, env)
   14. │                       └─quarto::quarto_render(...) at tests/testthat/setup.R:7:1
   15. │                         └─processx::run(quarto_bin, args, echo = TRUE)
   16. │                           └─throw(...)
   17. │                             └─base::signalCondition(cond)
   18. └─testthat (local) `<fn>`(`<systm___>`)
   19.   └─rlang::abort(...)
 ```