### PR TITLE
Use actions/checkout@v4.1.1 to mitigate git2r error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Cache artifacts 📀
         uses: actions/cache@v4
@@ -126,7 +126,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Cache artifacts 📀
         uses: actions/cache@v4
@@ -190,7 +190,7 @@ jobs:
         && !contains(github.event.commits[0].message, '[skip docs]')
     steps:
       - name: Checkout repo 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Download artifact ⏬
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Pin the checkout action to v4.1.1 since v4.1.3 is broken.
