### PR TITLE
remove redundant step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,27 +100,6 @@ jobs:
           name: site-development
           path: site.zip
 
-      - name: Remove large WebR assets 🧹
-        run: |
-          packages_path <- sprintf("./book/_site/site_libs/quarto-contrib/shinylive-%s/shinylive/webr/packages", shinylive::assets_version())
-
-          # remove the dirs with size > 100 MB
-          for (x in list.dirs(packages_path)) {
-            x_files <- file.info(list.files(x, full.names = TRUE))
-            if (any(x_files$size > 100 * 1024^2)) {
-              print(x)
-              print(x_files)
-              unlink(x, recursive = TRUE)
-            }
-          }
-
-          # refresh the `metadata.rds` file
-          metadata_path <- file.path(packages_path, "metadata.rds")
-          metadata <- readRDS(metadata_path)
-          new_metadata <- metadata[intersect(names(metadata), list.dirs(packages_path, full.names = FALSE))]
-          saveRDS(new_metadata, metadata_path)
-        shell: Rscript {0}
-
       - name: Publish docs 📔
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -185,27 +164,6 @@ jobs:
           zip -r9 ../../site.zip *
         shell: bash
         working-directory: book/_site
-
-      - name: Remove large WebR assets 🧹
-        run: |
-          packages_path <- sprintf("./book/_site/site_libs/quarto-contrib/shinylive-%s/shinylive/webr/packages", shinylive::assets_version())
-
-          # remove the dirs with size > 100 MB
-          for (x in list.dirs(packages_path)) {
-            x_files <- file.info(list.files(x, full.names = TRUE))
-            if (any(x_files$size > 100 * 1024^2)) {
-              print(x)
-              print(x_files)
-              unlink(x, recursive = TRUE)
-            }
-          }
-
-          # refresh the `metadata.rds` file
-          metadata_path <- file.path(packages_path, "metadata.rds")
-          metadata <- readRDS(metadata_path)
-          new_metadata <- metadata[intersect(names(metadata), list.dirs(packages_path, full.names = FALSE))]
-          saveRDS(new_metadata, metadata_path)
-        shell: Rscript {0}
 
       - name: Upload docs ⬆
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
follow-up on https://github.com/insightsengineering/tlg-catalog/pull/290

no need to clean-up assets if assets downloads is disabled

fixes errors in docs CI: https://github.com/insightsengineering/tlg-catalog/actions/runs/11989043816
```
Error in gzfile(file, "rb") : cannot open the connection
Calls: readRDS -> gzfile
In addition: Warning message:
In gzfile(file, "rb") :
  cannot open compressed file './book/_site/site_libs/quarto-contrib/shinylive-0.9.1/shinylive/webr/packages/metadata.rds', probable reason 'No such file or directory'
Execution halted
Error: Process completed with exit code 1.
```