### PR TITLE
Remove lookup-refs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,24 +34,6 @@ jobs:
         TLG_CATALOG_PKG_BUILD_RENDER=TRUE
       concurrency-group: development
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/random.cdisc.data
-        insightsengineering/formatters
-        insightsengineering/rlistings
-        insightsengineering/rtables
-        insightsengineering/tern
-        insightsengineering/tern.mmrm
-        insightsengineering/tern.rbmi
-        insightsengineering/teal.data
-        insightsengineering/teal.code
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.slice
-        insightsengineering/teal.transform
-        insightsengineering/teal.widgets
-        insightsengineering/teal
-        insightsengineering/teal.modules.general
-        insightsengineering/teal.modules.clinical
       skip-desc-dev: true
       repository-list: "r-universe-dev=https://pharmaverse.r-universe.dev/, PPM=PPM@latest"
       cache-version: "dev"

--- a/package/DESCRIPTION
+++ b/package/DESCRIPTION
@@ -47,6 +47,10 @@ Suggests:
     vdiffr,
     webshot2,
     withr
+Remotes:
+    insightsengineering/teal.modules.clinical,
+    insightsengineering/teal,
+    insightsengineering/tern
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 
```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CJ Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.