### PR TITLE
Fix/update teal api2

### DIFF
--- a/book/.gitignore
+++ b/book/.gitignore
@@ -12,3 +12,5 @@ assets/www/*.lock
 teal_app.lock
 
 /.quarto/
+
+**/*.quarto_ipynb

--- a/book/graphs/efficacy/fstg01.qmd
+++ b/book/graphs/efficacy/fstg01.qmd
@@ -261,9 +261,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADRS <- random.cdisc.data::cadrs
 })
-datanames <- c("ADSL", "ADRS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS")]
 
 arm_ref_comp <- list(
   ARM = list(

--- a/book/graphs/efficacy/fstg02.qmd
+++ b/book/graphs/efficacy/fstg02.qmd
@@ -265,9 +265,7 @@ data <- within(data, {
       AVALU = adtte_labels["AVALU"]
     )
 })
-datanames <- c("ADSL", "ADTTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/graphs/efficacy/kmg01.qmd
+++ b/book/graphs/efficacy/kmg01.qmd
@@ -207,9 +207,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADTTE <- random.cdisc.data::cadtte
 })
-datanames <- c("ADSL", "ADTTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
 
 arm_ref_comp <- list(
   ACTARMCD = list(

--- a/book/graphs/efficacy/mmrmg01.qmd
+++ b/book/graphs/efficacy/mmrmg01.qmd
@@ -132,9 +132,7 @@ data <- within(data, {
         as.factor() # making consecutive numeric factor
     )
 })
-datanames <- c("ADSL", "ADQS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADQS")]
 
 arm_ref_comp <- list(
   ARMCD = list(

--- a/book/graphs/other/bwg01.qmd
+++ b/book/graphs/other/bwg01.qmd
@@ -460,7 +460,7 @@ webr_code_labels <- c("plot9")
 ::: {.panel-tabset .nav-justified}
 ## {{< fa regular file-lines fa-sm fa-fw >}} Preview
 
-```{r teal, opts.label = c("skip_if_testing", "app"), eval = packageVersion("teal.modules.general") >= "0.3.0"}
+```{r teal, opts.label = c("skip_if_testing", "app")}
 library(teal.modules.general)
 
 ## Data reproducible code

--- a/book/graphs/other/bwg01.qmd
+++ b/book/graphs/other/bwg01.qmd
@@ -483,9 +483,7 @@ data <- within(data, {
   # study, subject, param and visit eg. filter with ANLFL = 'Y'
   stopifnot(nrow(ADLB) == nrow(unique(ADLB[, c("STUDYID", "USUBJID", "PARAMCD", "AVISIT")])))
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/graphs/other/cig01.qmd
+++ b/book/graphs/other/cig01.qmd
@@ -237,9 +237,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADLB <- random.cdisc.data::cadlb
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADLB <- data[["ADLB"]]

--- a/book/graphs/other/ippg01.qmd
+++ b/book/graphs/other/ippg01.qmd
@@ -135,9 +135,7 @@ data <- within(data, {
   ADLB <- df_explicit_na(ADLB) %>%
     filter(AVISIT != "SCREENING")
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADLB <- data[["ADLB"]]

--- a/book/graphs/other/mng01.qmd
+++ b/book/graphs/other/mng01.qmd
@@ -228,7 +228,7 @@ webr_code_labels <- c("plot7")
 ::: {.panel-tabset .nav-justified}
 ## {{< fa regular file-lines fa-sm fa-fw >}} Preview
 
-```{r teal, opts.label = c("skip_if_testing", "app"), eval = packageVersion("teal.modules.clinical") > "0.9.1"}
+```{r teal, opts.label = c("skip_if_testing", "app")}
 library(teal.modules.clinical)
 
 ## Data reproducible code

--- a/book/graphs/other/mng01.qmd
+++ b/book/graphs/other/mng01.qmd
@@ -241,9 +241,7 @@ data <- within(data, {
   ADLB <- random.cdisc.data::cadlb %>%
     mutate(AVISIT = fct_reorder(AVISIT, AVISITN, min))
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/ECG/egt01.qmd
+++ b/book/tables/ECG/egt01.qmd
@@ -119,9 +119,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADEG <- df_explicit_na(ADEG)
 })
-datanames <- c("ADSL", "ADEG")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEG")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/ECG/egt02.qmd
+++ b/book/tables/ECG/egt02.qmd
@@ -121,9 +121,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADEG <- random.cdisc.data::cadeg
 })
-datanames <- c("ADSL", "ADEG")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEG")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/ECG/egt03.qmd
+++ b/book/tables/ECG/egt03.qmd
@@ -182,9 +182,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADEG <- random.cdisc.data::cadeg
 })
-datanames <- c("ADSL", "ADEG")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEG")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/ECG/egt05_qtcat.qmd
+++ b/book/tables/ECG/egt05_qtcat.qmd
@@ -192,9 +192,7 @@ data <- within(data, {
     "CHGCAT1" = "Change from Baseline"
   )
 })
-datanames <- c("ADSL", "ADEG")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEG")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/adverse-events/aet01.qmd
+++ b/book/tables/adverse-events/aet01.qmd
@@ -431,9 +431,7 @@ data <- within(data, {
   # Generating user-defined event flags.
   ADAE <- ADAE %>% add_event_flags()
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/adverse-events/aet01_aesi.qmd
+++ b/book/tables/adverse-events/aet01_aesi.qmd
@@ -825,9 +825,7 @@ data <- within(data, {
       RELSER = with_label(AESER == "Y" & AEREL == "Y", "Serious related AE")
     )
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 aesi_vars <- c(
   "WD", "DSM", "CONTRT", "ALL_RESOLVED_WD", "ALL_RESOLVED_DSM", "ALL_RESOLVED_CONTRT",

--- a/book/tables/adverse-events/aet02.qmd
+++ b/book/tables/adverse-events/aet02.qmd
@@ -795,9 +795,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADAE <- df_explicit_na(ADAE)
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/adverse-events/aet02_smq.qmd
+++ b/book/tables/adverse-events/aet02_smq.qmd
@@ -219,9 +219,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADAE <- random.cdisc.data::cadae
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/adverse-events/aet03.qmd
+++ b/book/tables/adverse-events/aet03.qmd
@@ -133,9 +133,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADAE <- random.cdisc.data::cadae
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/adverse-events/aet04.qmd
+++ b/book/tables/adverse-events/aet04.qmd
@@ -652,9 +652,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADAE <- random.cdisc.data::cadae
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/adverse-events/aet04_pi.qmd
+++ b/book/tables/adverse-events/aet04_pi.qmd
@@ -461,9 +461,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADAE <- random.cdisc.data::cadae
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/adverse-events/aet05.qmd
+++ b/book/tables/adverse-events/aet05.qmd
@@ -125,9 +125,7 @@ data <- within(data, {
     mutate(is_event = CNSR == 0) %>%
     mutate(n_events = as.integer(is_event))
 })
-datanames <- c("ADSL", "ADAETTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAETTE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/adverse-events/aet05_all.qmd
+++ b/book/tables/adverse-events/aet05_all.qmd
@@ -133,9 +133,7 @@ data <- within(data, {
 
   ADAETTE <- full_join(anl_tte, anl_events, by = c("USUBJID", "STUDYID", "ARM", "ARMCD"))
 })
-datanames <- c("ADSL", "ADAETTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAETTE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/adverse-events/aet06.qmd
+++ b/book/tables/adverse-events/aet06.qmd
@@ -441,9 +441,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADAE <- df_explicit_na(ADAE)
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/adverse-events/aet06_smq.qmd
+++ b/book/tables/adverse-events/aet06_smq.qmd
@@ -313,9 +313,7 @@ data <- within(data, {
       )
     )
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/adverse-events/aet07.qmd
+++ b/book/tables/adverse-events/aet07.qmd
@@ -182,9 +182,7 @@ data <- within(data, {
     mutate(ARM = droplevels(ARM)) %>%
     col_relabel(SOC_PT = "MedDRA SOC and Preferred Term")
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/adverse-events/aet09.qmd
+++ b/book/tables/adverse-events/aet09.qmd
@@ -219,9 +219,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADAE <- df_explicit_na(ADAE)
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/adverse-events/aet09_smq.qmd
+++ b/book/tables/adverse-events/aet09_smq.qmd
@@ -225,9 +225,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADAE <- random.cdisc.data::cadae
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/adverse-events/aet10.qmd
+++ b/book/tables/adverse-events/aet10.qmd
@@ -149,9 +149,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADAE <- df_explicit_na(ADAE)
 })
-datanames <- c("ADSL", "ADAE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAE")]
 
 ## Reusable Configuration For Modules
 ADAE <- data[["ADAE"]]

--- a/book/tables/concomitant-medications/cmt01.qmd
+++ b/book/tables/concomitant-medications/cmt01.qmd
@@ -305,9 +305,7 @@ data <- within(data, {
     slice(1) %>%
     ungroup()
 })
-datanames <- c("ADSL", "ADCM")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADCM")]
 
 ## Reusable Configuration For Modules
 ADCM <- data[["ADCM"]]

--- a/book/tables/concomitant-medications/cmt01a.qmd
+++ b/book/tables/concomitant-medications/cmt01a.qmd
@@ -290,9 +290,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADCM <- df_explicit_na(ADCM)
 })
-datanames <- c("ADSL", "ADCM")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADCM")]
 join_keys(data)["ADCM", "ADCM"] <- adcm_keys
 
 ## Reusable Configuration For Modules

--- a/book/tables/concomitant-medications/cmt01b.qmd
+++ b/book/tables/concomitant-medications/cmt01b.qmd
@@ -311,9 +311,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADCM <- df_explicit_na(ADCM)
 })
-datanames <- c("ADSL", "ADCM")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADCM")]
 join_keys(data)["ADCM", "ADCM"] <- adcm_keys
 
 ## Reusable Configuration For Modules

--- a/book/tables/concomitant-medications/cmt02_pt.qmd
+++ b/book/tables/concomitant-medications/cmt02_pt.qmd
@@ -107,9 +107,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADCM <- df_explicit_na(ADCM)
 })
-datanames <- c("ADSL", "ADCM")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADCM")]
 join_keys(data)["ADCM", "ADCM"] <- adcm_keys
 
 ## Reusable Configuration For Modules

--- a/book/tables/demography/dmt01.qmd
+++ b/book/tables/demography/dmt01.qmd
@@ -274,9 +274,7 @@ data <- within(data, {
     any(is.na(ADSL$DCSREAS))
   )
 })
-datanames <- "ADSL"
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys["ADSL"]
 
 ## Setup App
 app <- init(

--- a/book/tables/disposition/dst01.qmd
+++ b/book/tables/disposition/dst01.qmd
@@ -192,9 +192,7 @@ data <- within(data, {
   date_vars_asl <- names(ADSL)[vapply(ADSL, function(x) inherits(x, c("Date", "POSIXct", "POSIXlt")), logical(1))]
   demog_vars_asl <- names(ADSL)[!(names(ADSL) %in% c("USUBJID", "STUDYID", date_vars_asl))]
 })
-datanames <- "ADSL"
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys["ADSL"]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/disposition/pdt01.qmd
+++ b/book/tables/disposition/pdt01.qmd
@@ -102,9 +102,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADDV <- df_explicit_na(ADDV)
 })
-datanames <- c("ADSL", "ADDV")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADDV")]
 
 ## Reusable Configuration For Modules
 ADDV <- data[["ADDV"]]

--- a/book/tables/efficacy/aovt01.qmd
+++ b/book/tables/efficacy/aovt01.qmd
@@ -99,9 +99,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADQS <- df_explicit_na(ADQS)
 })
-datanames <- c("ADSL", "ADQS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADQS")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/efficacy/aovt02.qmd
+++ b/book/tables/efficacy/aovt02.qmd
@@ -105,9 +105,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADQS <- df_explicit_na(ADQS)
 })
-datanames <- c("ADSL", "ADQS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADQS")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/efficacy/cfbt01.qmd
+++ b/book/tables/efficacy/cfbt01.qmd
@@ -127,9 +127,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADQS <- df_explicit_na(ADQS)
 })
-datanames <- c("ADSL", "ADQS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADQS")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/efficacy/cmht01.qmd
+++ b/book/tables/efficacy/cmht01.qmd
@@ -181,9 +181,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADRS <- random.cdisc.data::cadrs
 })
-datanames <- c("ADSL", "ADRS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS")]
 
 ## Reusable Configuration For Modules
 ADRS <- data[["ADRS"]]

--- a/book/tables/efficacy/coxt01.qmd
+++ b/book/tables/efficacy/coxt01.qmd
@@ -234,9 +234,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADTTE <- df_explicit_na(ADTTE)
 })
-datanames <- c("ADSL", "ADTTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
 
 ## Reusable Configuration For Modules
 ADTTE <- data[["ADTTE"]]

--- a/book/tables/efficacy/coxt02.qmd
+++ b/book/tables/efficacy/coxt02.qmd
@@ -166,9 +166,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADTTE <- random.cdisc.data::cadtte
 })
-datanames <- c("ADSL", "ADTTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
 
 ## Reusable Configuration For Modules
 ADTTE <- data[["ADTTE"]]

--- a/book/tables/efficacy/dort01.qmd
+++ b/book/tables/efficacy/dort01.qmd
@@ -327,9 +327,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADTTE <- df_explicit_na(ADTTE)
 })
-datanames <- c("ADSL", "ADTTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/efficacy/lgrt02.qmd
+++ b/book/tables/efficacy/lgrt02.qmd
@@ -219,9 +219,7 @@ data <- within(data, {
   ADRS <- random.cdisc.data::cadrs %>%
     filter(PARAMCD %in% c("BESRSPI", "INVET"))
 })
-datanames <- c("ADSL", "ADRS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS")]
 
 ## Reusable Configuration For Modules
 ADRS <- data[["ADRS"]]

--- a/book/tables/efficacy/mmrmt01.qmd
+++ b/book/tables/efficacy/mmrmt01.qmd
@@ -229,9 +229,7 @@ data <- within(data, {
         as.factor() # making consecutive numeric factor
     )
 })
-datanames <- c("ADSL", "ADQS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADQS")]
 
 ## Reusable Configuration For Modules
 ADQS <- data[["ADQS"]]

--- a/book/tables/efficacy/onct05.qmd
+++ b/book/tables/efficacy/onct05.qmd
@@ -201,9 +201,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADRS <- df_explicit_na(ADRS)
 })
-datanames <- c("ADSL", "ADRS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/efficacy/rspt01.qmd
+++ b/book/tables/efficacy/rspt01.qmd
@@ -334,9 +334,7 @@ data <- within(data, {
   ADRS <- ADRS %>%
     mutate(Dum_ARM = factor(rep("Single ARM", nrow(.))))
 })
-datanames <- c("ADSL", "ADRS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADRS")]
 
 ## Reusable Configuration For Modules
 ADRS <- data[["ADRS"]]

--- a/book/tables/efficacy/ttet01.qmd
+++ b/book/tables/efficacy/ttet01.qmd
@@ -480,9 +480,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADTTE <- df_explicit_na(ADTTE)
 })
-datanames <- c("ADSL", "ADTTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADTTE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/exposure/ext01.qmd
+++ b/book/tables/exposure/ext01.qmd
@@ -265,9 +265,7 @@ data <- within(data, {
     )
   col_labels(ADEX) <- c(adex_labels, "")
 })
-datanames <- c("ADSL", "ADEX")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEX")]
 
 ## Reusable Configuration For Modules
 ADEX <- data[["ADEX"]]

--- a/book/tables/lab-results/lbt01.qmd
+++ b/book/tables/lab-results/lbt01.qmd
@@ -123,9 +123,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADLB <- df_explicit_na(ADLB)
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt02.qmd
+++ b/book/tables/lab-results/lbt02.qmd
@@ -98,9 +98,7 @@ data <- within(data, {
   ADSL <- df_explicit_na(ADSL)
   ADLB <- df_explicit_na(ADLB)
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt03.qmd
+++ b/book/tables/lab-results/lbt03.qmd
@@ -179,9 +179,7 @@ data <- within(data, {
       AVISIT_header = "Analysis Visit"
     )
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt04.qmd
+++ b/book/tables/lab-results/lbt04.qmd
@@ -91,9 +91,7 @@ data <- within(data, {
   ADLB <- random.cdisc.data::cadlb %>%
     col_relabel(PARAM = "Laboratory Test", ANRIND = "Direction of Abnormality")
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt07.qmd
+++ b/book/tables/lab-results/lbt07.qmd
@@ -142,9 +142,7 @@ data <- within(data, {
   ADLB <- random.cdisc.data::cadlb %>%
     filter(!AVISIT %in% c("SCREENING", "BASELINE"))
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt07.qmd
+++ b/book/tables/lab-results/lbt07.qmd
@@ -130,7 +130,7 @@ webr_code_labels <- c("variant1")
 ::: {.panel-tabset .nav-justified}
 ## {{< fa regular file-lines fa-sm fa-fw >}} Preview
 
-```{r teal, opts.label = c("skip_if_testing", "app"), eval = packageVersion("teal.slice") > "0.5.1"}
+```{r teal, opts.label = c("skip_if_testing", "app")}
 library(teal.modules.clinical)
 
 ## Data reproducible code

--- a/book/tables/lab-results/lbt11.qmd
+++ b/book/tables/lab-results/lbt11.qmd
@@ -195,9 +195,7 @@ data <- within(data, {
   ADSL <- filter(ADSL, .data$SAFFL == "Y")
   ADAETTE <- filter(ADAETTE, .data$SAFFL == "Y")
 })
-datanames <- c("ADSL", "ADAETTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAETTE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt11_bl.qmd
+++ b/book/tables/lab-results/lbt11_bl.qmd
@@ -195,9 +195,7 @@ data <- within(data, {
   ADSL <- filter(ADSL, .data$SAFFL == "Y")
   ADAETTE <- filter(ADAETTE, .data$SAFFL == "Y")
 })
-datanames <- c("ADSL", "ADAETTE")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADAETTE")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt13.qmd
+++ b/book/tables/lab-results/lbt13.qmd
@@ -483,9 +483,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADLB <- random.cdisc.data::cadlb
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt14.qmd
+++ b/book/tables/lab-results/lbt14.qmd
@@ -385,9 +385,7 @@ data <- within(data, {
   ADSL <- random.cdisc.data::cadsl
   ADLB <- random.cdisc.data::cadlb
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/lab-results/lbt15.qmd
+++ b/book/tables/lab-results/lbt15.qmd
@@ -170,9 +170,7 @@ data <- within(data, {
     filter(ONTRTFL == "Y") %>%
     col_relabel(ANRIND = "Direction of Abnormality")
 })
-datanames <- c("ADSL", "ADLB")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADLB")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/medical-history/mht01.qmd
+++ b/book/tables/medical-history/mht01.qmd
@@ -229,9 +229,7 @@ data <- within(data, {
   ADMH <- random.cdisc.data::cadmh %>%
     filter(SAFFL == "Y" & MHBODSYS != "" & MHDECOD != "")
 })
-datanames <- c("ADSL", "ADMH")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADMH")]
 
 ## Reusable Configuration For Modules
 ADMH <- data[["ADMH"]]

--- a/book/tables/risk-management-plan/rmpt01.qmd
+++ b/book/tables/risk-management-plan/rmpt01.qmd
@@ -140,9 +140,7 @@ data <- within(data, {
     ) %>%
     select(-aval_months)
 })
-datanames <- c("ADSL", "ADEX")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEX")]
 
 ## Reusable Configuration For Modules
 ADEX <- data[["ADEX"]]

--- a/book/tables/risk-management-plan/rmpt03.qmd
+++ b/book/tables/risk-management-plan/rmpt03.qmd
@@ -196,9 +196,7 @@ data <- within(data, {
       SEX == "M" ~ "Male"
     )) %>% with_label("Sex"))
 })
-datanames <- c("ADSL", "ADEX")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEX")]
 
 ## Reusable Configuration For Modules
 ADEX <- data[["ADEX"]]

--- a/book/tables/risk-management-plan/rmpt04.qmd
+++ b/book/tables/risk-management-plan/rmpt04.qmd
@@ -121,9 +121,7 @@ data <- within(data, {
 
   col_labels(ADEX) <- labels
 })
-datanames <- c("ADSL", "ADEX")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEX")]
 
 ## Reusable Configuration For Modules
 ADEX <- data[["ADEX"]]

--- a/book/tables/risk-management-plan/rmpt05.qmd
+++ b/book/tables/risk-management-plan/rmpt05.qmd
@@ -123,9 +123,7 @@ data <- within(data, {
 
   col_labels(ADEX) <- labels
 })
-datanames <- c("ADSL", "ADEX")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADEX")]
 
 ## Reusable Configuration For Modules
 ADEX <- data[["ADEX"]]

--- a/book/tables/safety/enrollment01.qmd
+++ b/book/tables/safety/enrollment01.qmd
@@ -209,9 +209,7 @@ data <- within(data, {
 
   col_labels(ADSL) <- c(adsl_labels, c(INVID_INVNAM = "Investigator Number/Name"))
 })
-datanames <- "ADSL"
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys["ADSL"]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/vital-signs/vst01.qmd
+++ b/book/tables/vital-signs/vst01.qmd
@@ -197,9 +197,7 @@ data <- within(data, {
 
   col_labels(ADVS) <- advs_label
 })
-datanames <- c("ADSL", "ADVS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADVS")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]

--- a/book/tables/vital-signs/vst02.qmd
+++ b/book/tables/vital-signs/vst02.qmd
@@ -124,9 +124,7 @@ data <- within(data, {
     mutate(ONTRTFL = ifelse(AVISIT %in% c("SCREENING", "BASELINE"), "", "Y")) %>%
     col_relabel(ONTRTFL = "On Treatment Record Flag")
 })
-datanames <- c("ADSL", "ADVS")
-names(data) <- datanames
-join_keys(data) <- default_cdisc_join_keys[datanames]
+join_keys(data) <- default_cdisc_join_keys[c("ADSL", "ADVS")]
 
 ## Reusable Configuration For Modules
 ADSL <- data[["ADSL"]]


### PR DESCRIPTION
Follow up on https://github.com/insightsengineering/tlg-catalog/pull/311

Renaming is redundant and not really needed. We still have warnings after recent changes from `datanames(x)<-` into `names(x)<-`.
In addition, I removed version check as this is already true for quite a while now